### PR TITLE
Update adjointJacobian, Skip over Identity ops, and Remove deprecated tape exec methods

### DIFF
--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -152,7 +152,13 @@ class LightningGPU(LightningQubit):
         return super().statistics(observables, shot_range, bin_size)
 
     def apply_cq(self, operations, **kwargs):
+        # Skip over identity operations instead of performing
+        # matrix multiplication with the identity.
+        skipped_ops = ["Identity"]
+
         for o in operations:
+            if o.base_name in skipped_ops:
+                continue
             name = o.name.split(".")[0]  # The split is because inverse gates have .inv appended
             method = getattr(self._gpu_state, name, None)
 

--- a/pennylane_lightning_gpu/src/tests/Test_AdjointDiffGPU.cpp
+++ b/pennylane_lightning_gpu/src/tests/Test_AdjointDiffGPU.cpp
@@ -1,5 +1,3 @@
-#define _USE_MATH_DEFINES
-
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -16,6 +14,10 @@
 #include "StateVectorCudaManaged.hpp"
 #include "TestHelpers.hpp"
 #include "Util.hpp"
+
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 
 using namespace Pennylane::CUDA;
 using namespace Pennylane::Algorithms;

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -312,12 +312,11 @@ class TestAdjointJacobian:
             qml.expval(obs(wires=0))
             qml.expval(qml.PauliZ(wires=1))
 
-        tape.execute(dev_gpu)
-
         tape.trainable_params = set(range(1, 1 + op.num_params))
 
-        gtapes, fn = qml.gradients.param_shift(tape)
-        grad_PS = fn(qml.execute(gtapes, dev_gpu, gradient_fn=None))
+        grad_PS = (lambda t, fn: fn(qml.execute(t, dev_gpu, None)))(
+            *qml.gradients.param_shift(tape)
+        )
         grad_D = dev_gpu.adjoint_jacobian(tape)
 
         assert np.allclose(grad_D, grad_PS, atol=tol, rtol=0)
@@ -359,7 +358,7 @@ class TestAdjointJacobian:
 
         dM1 = dev_gpu.adjoint_jacobian(tape)
 
-        tape.execute(dev_gpu)
+        qml.execute([tape], dev_gpu, None)
         dM2 = dev_gpu.adjoint_jacobian(tape, use_device_state=True)
 
         assert np.allclose(dM1, dM2, atol=tol, rtol=0)
@@ -378,7 +377,7 @@ class TestAdjointJacobian:
 
         dM1 = dev_gpu.adjoint_jacobian(tape)
 
-        tape.execute(dev_gpu)
+        qml.execute([tape], dev_gpu, None)
         dM2 = dev_gpu.adjoint_jacobian(tape, starting_state=dev_gpu._pre_rotated_state)
 
         assert np.allclose(dM1, dM2, atol=tol, rtol=0)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1153,6 +1153,43 @@ class TestTensorVar:
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
 
+class TestApplyCQMethod:
+    """Unit tests for the apply_cq method."""
+
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_apply_identity_skipped(self, C, tol):
+        """Test identity operation does not perform additional computations."""
+        dev = qml.device("lightning.gpu", wires=1)
+        dev._state = dev._asarray(dev._gpu_state, C)
+
+        starting_state = np.array([1, 0], dtype=C)
+        op = [qml.Identity(0)]
+        dev.apply(op)
+
+        assert np.allclose(dev._gpu_state, starting_state, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_iter_identity_skipped(self, mocker, C, tol):
+        """Test identity operations do not perform additional computations."""
+        dev = qml.device("lightning.gpu", wires=2)
+        if not hasattr(dev, "apply_cq"):
+            pytest.skip("LightningGPU object has no attribute apply_cq")
+
+        starting_state = np.array([1, 0, 0, 0], dtype=C)
+        op = [qml.Identity(0), qml.Identity(1)]
+
+        spy_diagonal = mocker.spy(dev, "_apply_diagonal_unitary")
+        spy_einsum = mocker.spy(dev, "_apply_unitary_einsum")
+        spy_unitary = mocker.spy(dev, "_apply_unitary")
+
+        dev.apply_cq(op, dtype=C)
+        assert np.allclose(dev._gpu_state, starting_state, atol=tol, rtol=0)
+
+        spy_diagonal.assert_not_called()
+        spy_einsum.assert_not_called()
+        spy_unitary.assert_not_called()
+
+
 # Tolerance for non-analytic tests
 TOL_STOCHASTIC = 0.05
 


### PR DESCRIPTION
**Context:**
- Update the `adjointJacobian` method;
- Fix issue [#267](https://github.com/PennyLaneAI/pennylane-lightning/issues/267); and 
- Fix issue [#269](https://github.com/PennyLaneAI/pennylane-lightning/issues/269).