### PR TITLE
Update builder and cuQuantum SDK support

### DIFF
--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
-  CIBW_BUILD_FRONTEND: "build"
+  CIBW_BUILD_FRONTEND: "pip"
   CIBW_SKIP: "*-musllinux*"
 
   # Python build settings

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -63,7 +63,7 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
 
       - uses: actions/upload-artifact@v2
-        #if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || steps.rc_build.outputs.match != ''}}
+        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || steps.rc_build.outputs.match != ''}}
         with:
           name: ${{ runner.os }}-wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -13,7 +13,8 @@ env:
 
   # Python build settings
   CIBW_BEFORE_BUILD: |
-    pip install pybind11 ninja cmake auditwheel && pip install --no-deps cuquantum && yum install -y gcc gcc-c++
+    python -m pip install pybind11 ninja cmake auditwheel && python -m pip install --no-deps cuquantum 
+    yum install -y gcc gcc-c++
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
     yum clean all
     yum -y install cuda cmake git openssh wget

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -13,15 +13,13 @@ env:
 
   # Python build settings
   CIBW_BEFORE_BUILD: |
-    pip install pybind11 ninja cmake auditwheel && yum install -y gcc gcc-c++
+    pip install pybind11 ninja cmake auditwheel && pip install --no-deps cuquantum && yum install -y gcc gcc-c++
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
     yum clean all
     yum -y install cuda cmake git openssh wget
-    wget -P /project https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/cuquantum-linux-x86_64-22.03.0.40-archive.tar.xz
-    tar xvf /project/cuquantum-linux-x86_64-22.03.0.40-archive.tar.xz -C /project
 
   # ensure nvcc is available
-  CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/cuda/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/project/cuquantum-linux-x86_64-22.03.0.40-archive/lib CUQUANTUM_SDK=/project/cuquantum-linux-x86_64-22.03.0.40-archive
+  CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/cuda/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:$(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")
 
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_REPAIR_WHEEL_COMMAND_LINUX: "./docker/auditwheel repair -w {dest_dir} {wheel}"

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -63,7 +63,7 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || steps.rc_build.outputs.match != ''}}
+        #if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || steps.rc_build.outputs.match != ''}}
         with:
           name: ${{ runner.os }}-wheels
           path: ./wheelhouse/*.whl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,13 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
+# Ensure the libraries can see additional libs at same level;
+# Required for external deps when loading in Python
+set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+set(CMAKE_BUILD_RPATH "$ORIGIN/../cuquantum/lib:$ORIGIN/")
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../cuquantum/lib:$ORIGIN/")
+
 if(ENABLE_CLANG_TIDY)
     if (NOT DEFINED CLANG_TIDY_BINARY)
         set(CLANG_TIDY_BINARY clang-tidy)
@@ -101,8 +108,10 @@ if(ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)
 endif()
 
+find_package (Python COMPONENTS Interpreter Development)
+
 find_library(CUSTATEVEC_LIB
-    NAMES   libcustatevec custatevec
+    NAMES   libcustatevec.so.1 custatevec.so.1
     HINTS   /usr/lib
             /usr/local/cuda
             /usr/local/lib
@@ -115,6 +124,7 @@ find_library(CUSTATEVEC_LIB
             ${CUDAToolkit_LIBRARY_DIR}
             ${CUDA_TOOLKIT_ROOT_DIR}/lib
             ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+            ${Python_SITELIB}/cuquantum/lib
             ENV LD_LIBRARY_PATH
 )
 
@@ -129,6 +139,7 @@ find_file( CUSTATEVEC_INC
             ${CUQUANTUM_SDK}/include
             ${CUDAToolkit_INCLUDE_DIRS}
             ${CUDA_TOOLKIT_ROOT_DIR}/include
+            ${Python_SITELIB}/cuquantum/include
             ENV CPATH
 )
 
@@ -158,6 +169,7 @@ if(ENABLE_PYTHON)
     pybind11_add_module(lightning_gpu_qubit_ops     "pennylane_lightning_gpu/src/bindings/Bindings.cpp")
     target_link_libraries(lightning_gpu_qubit_ops PRIVATE pennylane_lightning_gpu)
     set_target_properties(lightning_gpu_qubit_ops PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties(lightning_gpu_qubit_ops PROPERTIES INSTALL_RPATH "$ORIGIN/../cuquantum/lib:$ORIGIN/")
     target_compile_options(lightning_gpu_qubit_ops PRIVATE "$<$<CONFIG:RELEASE>:-W>")
     target_compile_definitions(lightning_gpu_qubit_ops PRIVATE VERSION_INFO=${VERSION_STRING})
     target_include_directories(lightning_gpu_qubit_ops PRIVATE ${CUDA_TOOLKIT_ROOT_DIR}/include)
@@ -168,6 +180,8 @@ endif()
 # string(REPLACE "libcudart_static.a" "libcudart.so" CUDA_SHARED_RT "${CUDA_LIBRARIES}")
 target_include_directories(pennylane_lightning_gpu INTERFACE ${CUDA_TOOLKIT_ROOT_DIR}/include)
 target_link_libraries(pennylane_lightning_gpu INTERFACE CUDA::cudart)
+set_target_properties(pennylane_lightning_gpu PROPERTIES INSTALL_RPATH "$ORIGIN/../cuquantum/lib:$ORIGIN/")
+
 if(ENABLE_OPENMP)
 	target_link_libraries(pennylane_lightning_gpu INTERFACE OpenMP::OpenMP_CXX)
 endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,19 +9,16 @@ RUN yum-config-manager --add-repo https://developer.download.nvidia.com/compute/
 
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-# Fetch cuQuantum
-RUN wget https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/cuquantum-linux-x86_64-22.03.0.40-archive.tar.xz && tar xvf ./cuquantum-linux-x86_64-22.03.0.40-archive.tar.xz
-
 COPY ./  /pennylane-lightning-gpu
 
 # Create venv for each required Python version
 RUN cd /pennylane-lightning-gpu \
     && export PATH=$PATH:/usr/local/cuda/bin \
-    && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/cuquantum-linux-x86_64-22.03.0.40-archive/lib \
-    && for i in {7..10}; do python3.${i} -m venv pyenv3.${i}; source pyenv3.${i}/bin/activate && python3 -m pip install auditwheel ninja wheel && python3 setup.py build_ext --cuquantum=/cuquantum-linux-x86_64-22.03.0.40-archive --define=CMAKE_CXX_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/g++ --define=ENABLE_CLANG_TIDY=0  && python3 setup.py bdist_wheel && deactivate && rm -rf ./build ; done
+    && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64 \
+    && for i in {7..10}; do python3.${i} -m venv pyenv3.${i}; source pyenv3.${i}/bin/activate && python3 -m pip install auditwheel ninja wheel && python -m pip install --no-deps cuquantum && python3 setup.py build_ext --define=CMAKE_CXX_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/g++ --define=ENABLE_CLANG_TIDY=0  && python3 setup.py bdist_wheel && deactivate && rm -rf ./build ; done
 
 RUN cd /pennylane-lightning-gpu \
     && export PATH=$PATH:/usr/local/cuda/bin \
-    && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/cuquantum-linux-x86_64-22.03.0.40-archive/lib \
     && source pyenv3.10/bin/activate \
+    && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:$(python -c "import site; print(site.getsitepackages()[0])")/cuquantum/lib \
     && for i in $(ls ./dist); do /pennylane-lightning-gpu/docker/auditwheel repair -w /wheelhouse /pennylane-lightning-gpu/dist/$i; done

--- a/docker/auditwheel
+++ b/docker/auditwheel
@@ -3,18 +3,12 @@
 # Patch to not ship CUDA system libraries
 # Follows https://github.com/DIPlib/diplib/tree/master/tools/travis
 import sys
-from ctypes.util import find_library
 
 from auditwheel.main import main
 from auditwheel.policy import _POLICIES as POLICIES
 
 # Do not include licensed dynamic libraries
-libs = ["libcudart.so.11.0", "libcublasLt.so.11", "libcublas.so.11"]
-
-# Find versioned custatevec and do not include in wheel
-sv = (find_library('custatevec'))
-if sv:
-    libs.append(sv)
+libs = ["libcudart.so.11.0", "libcublasLt.so.11", "libcublas.so.11", "libcustatevec.so.1"]
 
 print(f"Excluding {libs}")
 

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -56,10 +56,12 @@ try:
 
     from ._serialize import _serialize_obs, _serialize_ops
     from ctypes.util import find_library
+    from importlib import util as imp_util
 
-    if find_library("custatevec") == None:
+    if find_library("custatevec") == None and not imp_util.find_spec("cuquantum"):
         raise ImportError(
-            'cuQuantum libraries not found. Please check "LD_LIBRARY_PATH" environment variable.'
+            'cuQuantum libraries not found. Please check your "LD_LIBRARY_PATH" environment variable,'
+            'or ensure you have installed the appropriate distributable "cuQuantum" package.'
         )
     if not is_gpu_supported():
         raise ValueError(f"CUDA device is an unsupported version: {get_gpu_arch()}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ninja
 cmake
+cuquantum>=22.3.0
 flaky
 numpy
 pennylane>=0.22


### PR DESCRIPTION
**Context:** As cuQuantum is now available on [PyPI](https://pypi.org/project/cuquantum/), we can add supports for user-installed packages to automatically refer to this version of the package, if installed. In addition, we update the wheel-builders to ensure the package is installed from PyPI.

**Description of the Change:** Allow cuQuantum installed from PyPI to be automatically picked up by installed LightningGPU C++ modules. Build support for external modules to use SDK headers & linkage from PyPI installed package. All licensed libs explicitly stripped from wheel in `auditwheel`.

**Benefits:** Easier for end-users to use `lightning.gpu`

**Possible Drawbacks:**

**Related GitHub Issues:**
