### PR TITLE
Update the error message associated with using finite shots

### DIFF
--- a/bin/format
+++ b/bin/format
@@ -19,7 +19,7 @@ IGNORE_PATTERN = ["external"]
 
 DEFAULT_CLANG_FORMAT_VERSION=12
 
-BASE_CMD = (f"clang-format", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
+BASE_CMD = (f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
 
 def parse_version(version_string):
     version_rgx = "version (\d+)"
@@ -28,7 +28,7 @@ def parse_version(version_string):
     return int(m.group(1))
 
 def check_bin():
-    command = f"clang-format"
+    command = f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}"
     try:
         p = subprocess.run([command, "--version"], 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -117,6 +117,9 @@ class LightningGPU(LightningQubit):
     }
 
     def __init__(self, wires, *, shots=None, sync=True):
+        if shots is not None:
+            raise ValueError(f"lightning.gpu does not support finite shots, please use shots=None")
+
         super().__init__(wires, shots=shots)
         self._gpu_state = _gpu_dtype(self._state.dtype)(self._state)
         self._sync = sync

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -569,6 +569,14 @@ class TestLightningGPUIntegration:
         assert dev.shots is None
         assert dev.short_name == "lightning.gpu"
 
+    def test_with_shots(self):
+        """Test that lightning.gpu does not support finite shots"""
+
+        with pytest.raises(
+            ValueError, match="lightning.gpu does not support finite shots, please use shots=None"
+        ):
+            qml.device("lightning.gpu", wires=2, shots=1)
+
     def test_no_backprop(self):
         """Test that lightning.gpu does not support the backprop
         differentiation method."""


### PR DESCRIPTION
**Context:**
Currently, `lightning.gpu` doesn't support finite shots and any tries with `shots > 0` will raise an _unclear_ error. This PR addresses this issue with raising a clear error message.  
