### PR TITLE
Create bug-fix release 0.23.1

### DIFF
--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -17,7 +17,6 @@ env:
     yum install -y gcc gcc-c++
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
     yum clean all
-    yum --enablerepo=cuda-rhel7-x86_64 clean metadata
     yum -y install cuda cmake git openssh wget
 
   # ensure nvcc is available

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -17,6 +17,7 @@ env:
     yum install -y gcc gcc-c++
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
     yum clean all
+    yum --enablerepo=cuda-rhel7-x86_64 clean metadata
     yum -y install cuda cmake git openssh wget
 
   # ensure nvcc is available

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -46,4 +46,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run formatter
-        run: ./bin/format --check ./pennylane_lightning_gpu/src
+        run: ./bin/format --check --cfversion 12 ./pennylane_lightning_gpu/src

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ help:
 	@echo "  test-cpp           to run the C++ test suite"
 	@echo "  test-python        to run the Python test suite"
 	@echo "  coverage           to generate a coverage report"
-	@echo "  format [check=1]   to apply C++ formatter; use with 'check=1' to check instead of modify (requires clang-format)"
+	@echo "  format [check=1]   to apply C++ and Python formatter; use with 'check=1' to check instead of modify (requires black and clang-format)"
+	@echo "  format [version=?] to apply C++ and Python formatter; use with 'version={version}' to check or modify with clang-format-{version} instead of clang-format"
 	@echo "  check-tidy         to build PennyLane-Lightning-GPU with ENABLE_CLANG_TIDY=ON (requires clang-tidy & CMake)"
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,9 @@ format: format-cpp format-python
 
 format-cpp:
 ifdef check
-	./bin/format --check pennylane_lightning_gpu/src ./tests
+	./bin/format --check --cfversion $(if $(version:-=),$(version),0) pennylane_lightning_gpu/src ./tests
 else
-	./bin/format pennylane_lightning_gpu/src ./tests
+	./bin/format --cfversion $(if $(version:-=),$(version),0) pennylane_lightning_gpu/src ./tests
 endif
 
 format-python:

--- a/bin/format
+++ b/bin/format
@@ -19,7 +19,7 @@ IGNORE_PATTERN = ["external"]
 
 DEFAULT_CLANG_FORMAT_VERSION=12
 
-BASE_CMD = (f"clang-format", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
+BASE_CMD = (f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
 
 def parse_version(version_string):
     version_rgx = "version (\d+)"
@@ -28,7 +28,7 @@ def parse_version(version_string):
     return int(m.group(1))
 
 def check_bin():
-    command = f"clang-format"
+    command = f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}"
     try:
         p = subprocess.run([command, "--version"], 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)

--- a/bin/format
+++ b/bin/format
@@ -19,16 +19,13 @@ IGNORE_PATTERN = ["external"]
 
 DEFAULT_CLANG_FORMAT_VERSION=12
 
-BASE_CMD = (f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
-
 def parse_version(version_string):
     version_rgx = "version (\d+)"
 
     m = re.search(version_rgx, version_string)
     return int(m.group(1))
 
-def check_bin():
-    command = f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}"
+def check_bin(command):
     try:
         p = subprocess.run([command, "--version"], 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
@@ -64,7 +61,14 @@ def parse_args():
         action="store_true",
         help="print detailed information about format violations",
     )
-
+    parser.add_argument(
+        "-f",
+        "--cfversion",
+        type=int,
+        default=0,
+        action="store",
+        help="set a version number for clang-format",
+    )
     return parser.parse_args()
 
 
@@ -79,8 +83,8 @@ def get_files(args):
     return [f for f in files if f not in IGNORE_PATTERN]
 
 
-def fmt(args, files) -> int:
-    cmd = (*BASE_CMD, "-i", *files)
+def fmt(args, files, command) -> int:
+    cmd = (command, f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}", "-i", *files)
 
     paths = ", ".join(args.paths)
     sys.stderr.write(f"Formatting {len(files)} files in {paths}.\n")
@@ -93,18 +97,18 @@ def fmt(args, files) -> int:
     return 0
 
 
-def check(args, files) -> int:
-    cmd = (*BASE_CMD, "--dry-run", "-Werror")
+def check(args, files, command) -> int:
+    cmd = (command, f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}", "--dry-run", "-Werror")
 
     needs_reformatted_ct = 0
 
-    for src_file in files:
+    for file in files:
         ret = subprocess.run(
-            (*cmd, src_file), capture_output=True, universal_newlines=True
+            (*cmd, file), capture_output=True, universal_newlines=True
         )
 
         if ret.returncode != 0:
-            sys.stderr.write(f"Error: {src_file} would be reformatted.\n")
+            sys.stderr.write(f"Error: {file} would be reformatted.\n")
             if args.verbose:
                 sys.stderr.write(ret.stderr)
 
@@ -117,7 +121,6 @@ def check(args, files) -> int:
 
 
 if __name__ == "__main__":
-    check_bin()
     args = parse_args()
 
     files = get_files(args)
@@ -126,9 +129,17 @@ if __name__ == "__main__":
         print("No source files found! Nothing to do.")
         sys.exit(0)
 
+    cf_version = args.cfversion
+    cf_cmd = "clang-format"
+
+    if cf_version:
+        cf_cmd += f"-{cf_version}"
+
+    check_bin(cf_cmd)
+
     if args.check:
-        ret = check(args, files)
+        ret = check(args, files, cf_cmd)
     else:
-        ret = fmt(args, files)
+        ret = fmt(args, files, cf_cmd)
 
     sys.exit(int(ret > 0))

--- a/bin/format
+++ b/bin/format
@@ -19,7 +19,7 @@ IGNORE_PATTERN = ["external"]
 
 DEFAULT_CLANG_FORMAT_VERSION=12
 
-BASE_CMD = (f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
+BASE_CMD = (f"clang-format", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
 
 def parse_version(version_string):
     version_rgx = "version (\d+)"
@@ -28,7 +28,7 @@ def parse_version(version_string):
     return int(m.group(1))
 
 def check_bin():
-    command = f"clang-format-{DEFAULT_CLANG_FORMAT_VERSION}"
+    command = f"clang-format"
     try:
         p = subprocess.run([command, "--version"], 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)

--- a/bin/format
+++ b/bin/format
@@ -19,6 +19,8 @@ IGNORE_PATTERN = ["external"]
 
 DEFAULT_CLANG_FORMAT_VERSION=12
 
+BASE_ARGS = f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}"
+
 def parse_version(version_string):
     version_rgx = "version (\d+)"
 
@@ -84,7 +86,7 @@ def get_files(args):
 
 
 def fmt(args, files, command) -> int:
-    cmd = (command, f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}", "-i", *files)
+    cmd = (command, BASE_ARGS, "-i", *files)
 
     paths = ", ".join(args.paths)
     sys.stderr.write(f"Formatting {len(files)} files in {paths}.\n")
@@ -98,7 +100,7 @@ def fmt(args, files, command) -> int:
 
 
 def check(args, files, command) -> int:
-    cmd = (command, f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}", "--dry-run", "-Werror")
+    cmd = (command, BASE_ARGS, "--dry-run", "-Werror")
 
     needs_reformatted_ct = 0
 

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -118,7 +118,7 @@ class LightningGPU(LightningQubit):
 
     def __init__(self, wires, *, shots=None, sync=True):
         if shots is not None:
-            raise ValueError(f"lightning.gpu does not support finite shots, please use shots=None")
+            raise ValueError("lightning.gpu does not support finite shots, please use shots=None")
 
         super().__init__(wires, shots=shots)
         self._gpu_state = _gpu_dtype(self._state.dtype)(self._state)

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -117,7 +117,7 @@ class LightningGPU(LightningQubit):
     }
 
     def __init__(self, wires, *, shots=None, sync=True):
-        if shots is not None:
+        if shots:
             raise ValueError("lightning.gpu does not support finite shots, please use shots=None")
 
         super().__init__(wires, shots=shots)

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -117,6 +117,9 @@ class LightningGPU(LightningQubit):
     }
 
     def __init__(self, wires, *, shots=None, sync=True):
+        if shots is not None:
+            raise ValueError(f"lightning.gpu does not support finite shots, please use shots=None")
+
         super().__init__(wires, shots=shots)
         self._gpu_state = _gpu_dtype(self._state.dtype)(self._state)
         self._sync = sync

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -649,6 +649,30 @@ class TestLightningGPUIntegration:
 
         assert np.isclose(circuit(p), 1, atol=tol, rtol=0)
 
+    def test_nonzero_shots(self, tol):
+        """Test that the default qubit plugin provides correct result for high shot number"""
+
+        shots = 10**4
+
+        with pytest.raises(
+            ValueError, match="lightning.gpu does not support finite shots, please use shots=None"
+        ):
+            dev = qml.device("lightning.gpu", wires=1, shots=shots)
+
+        # p = 0.543
+
+        # @qml.qnode(dev)
+        # def circuit(x):
+        #     """Test quantum function"""
+        #     qml.RX(x, wires=0)
+        #     return qml.expval(qml.PauliY(0))
+
+        # runs = []
+        # for _ in range(100):
+        #     runs.append(circuit(p))
+
+        # assert np.isclose(np.mean(runs), -np.sin(p), atol=1e-2, rtol=0)
+
     # This test is ran against the state |0> with one Z expval
     @pytest.mark.parametrize(
         "name,expected_output",

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -569,6 +569,14 @@ class TestLightningGPUIntegration:
         assert dev.shots is None
         assert dev.short_name == "lightning.gpu"
 
+    def test_with_shots(self):
+        """Test that lightning.gpu does not support finite shots"""
+
+        with pytest.raises(
+            ValueError, match="lightning.gpu does not support finite shots, please use shots=None"
+        ):
+            qml.device("lightning.gpu", wires=2, shots=1)
+
     def test_no_backprop(self):
         """Test that lightning.gpu does not support the backprop
         differentiation method."""

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -569,6 +569,12 @@ class TestLightningGPUIntegration:
         assert dev.shots is None
         assert dev.short_name == "lightning.gpu"
 
+    def test_with_shots_zero(self):
+        """Test that lightning.gpu supports zero shots"""
+
+        dev = qml.device("lightning.gpu", wires=2, shots=0)
+        assert dev.shots == 0
+
     def test_with_shots(self):
         """Test that lightning.gpu does not support finite shots"""
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -572,8 +572,10 @@ class TestLightningGPUIntegration:
     def test_with_shots_zero(self):
         """Test that lightning.gpu supports zero shots"""
 
-        dev = qml.device("lightning.gpu", wires=2, shots=0)
-        assert dev.shots == 0
+        with pytest.raises(
+            DeviceError, match="The specified number of shots needs to be at least 1. Got 0."
+        ):
+            qml.device("lightning.gpu", wires=2, shots=0)
 
     def test_with_shots(self):
         """Test that lightning.gpu does not support finite shots"""
@@ -646,26 +648,6 @@ class TestLightningGPUIntegration:
             return qml.expval(qml.Identity(0))
 
         assert np.isclose(circuit(p), 1, atol=tol, rtol=0)
-
-    def test_nonzero_shots(self, tol):
-        """Test that the default qubit plugin provides correct result for high shot number"""
-
-        shots = 10**4
-        dev = qml.device("lightning.gpu", wires=1, shots=shots)
-
-        p = 0.543
-
-        @qml.qnode(dev)
-        def circuit(x):
-            """Test quantum function"""
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliY(0))
-
-        runs = []
-        for _ in range(100):
-            runs.append(circuit(p))
-
-        assert np.isclose(np.mean(runs), -np.sin(p), atol=1e-2, rtol=0)
 
     # This test is ran against the state |0> with one Z expval
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
- Currently, `lightning.gpu` doesn't support finite shots. This PR adds a clear error message for any tries with `shots != None`.  
- `make format` (and `make format-cpp`) now accepts the version number in case `clang-format` is not installed or not satisfying the default version -- that is currently `12`. This update avoids inconsistencies between different clang-format aliases and eases trying different versions when needed. 