### PR TITLE
Fix the issue with using available clang-format version in format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -46,4 +46,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run formatter
-        run: ./bin/format --check ./pennylane_lightning_gpu/src
+        run: ./bin/format --check --cfversion 12 ./pennylane_lightning_gpu/src

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ help:
 	@echo "  test-cpp           to run the C++ test suite"
 	@echo "  test-python        to run the Python test suite"
 	@echo "  coverage           to generate a coverage report"
-	@echo "  format [check=1]   to apply C++ formatter; use with 'check=1' to check instead of modify (requires clang-format)"
+	@echo "  format [check=1]   to apply C++ and Python formatter; use with 'check=1' to check instead of modify (requires black and clang-format)"
+	@echo "  format [version=?] to apply C++ and Python formatter; use with 'version={version}' to check or modify with clang-format-{version} instead of clang-format"
 	@echo "  check-tidy         to build PennyLane-Lightning-GPU with ENABLE_CLANG_TIDY=ON (requires clang-tidy & CMake)"
 
 .PHONY: install
@@ -89,9 +90,9 @@ format: format-cpp format-python
 
 format-cpp:
 ifdef check
-	./bin/format --check pennylane_lightning_gpu/src ./tests
+	./bin/format --check --cfversion $(if $(version:-=),$(version),0) pennylane_lightning_gpu/src ./tests
 else
-	./bin/format pennylane_lightning_gpu/src ./tests
+	./bin/format --cfversion $(if $(version:-=),$(version),0) pennylane_lightning_gpu/src ./tests
 endif
 
 format-python:

--- a/bin/format
+++ b/bin/format
@@ -19,7 +19,7 @@ IGNORE_PATTERN = ["external"]
 
 DEFAULT_CLANG_FORMAT_VERSION=12
 
-BASE_CMD = (f"clang-format", f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}")
+BASE_ARGS = f"-style={json.dumps(CLANG_FMT_STYLE_CFG)}"
 
 def parse_version(version_string):
     version_rgx = "version (\d+)"
@@ -27,8 +27,7 @@ def parse_version(version_string):
     m = re.search(version_rgx, version_string)
     return int(m.group(1))
 
-def check_bin():
-    command = f"clang-format"
+def check_bin(command):
     try:
         p = subprocess.run([command, "--version"], 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
@@ -64,7 +63,14 @@ def parse_args():
         action="store_true",
         help="print detailed information about format violations",
     )
-
+    parser.add_argument(
+        "-f",
+        "--cfversion",
+        type=int,
+        default=0,
+        action="store",
+        help="set a version number for clang-format",
+    )
     return parser.parse_args()
 
 
@@ -79,8 +85,8 @@ def get_files(args):
     return [f for f in files if f not in IGNORE_PATTERN]
 
 
-def fmt(args, files) -> int:
-    cmd = (*BASE_CMD, "-i", *files)
+def fmt(args, files, command) -> int:
+    cmd = (command, BASE_ARGS, "-i", *files)
 
     paths = ", ".join(args.paths)
     sys.stderr.write(f"Formatting {len(files)} files in {paths}.\n")
@@ -93,18 +99,18 @@ def fmt(args, files) -> int:
     return 0
 
 
-def check(args, files) -> int:
-    cmd = (*BASE_CMD, "--dry-run", "-Werror")
+def check(args, files, command) -> int:
+    cmd = (command, BASE_ARGS, "--dry-run", "-Werror")
 
     needs_reformatted_ct = 0
 
-    for src_file in files:
+    for file in files:
         ret = subprocess.run(
-            (*cmd, src_file), capture_output=True, universal_newlines=True
+            (*cmd, file), capture_output=True, universal_newlines=True
         )
 
         if ret.returncode != 0:
-            sys.stderr.write(f"Error: {src_file} would be reformatted.\n")
+            sys.stderr.write(f"Error: {file} would be reformatted.\n")
             if args.verbose:
                 sys.stderr.write(ret.stderr)
 
@@ -117,7 +123,6 @@ def check(args, files) -> int:
 
 
 if __name__ == "__main__":
-    check_bin()
     args = parse_args()
 
     files = get_files(args)
@@ -126,9 +131,17 @@ if __name__ == "__main__":
         print("No source files found! Nothing to do.")
         sys.exit(0)
 
+    cf_version = args.cfversion
+    cf_cmd = "clang-format"
+
+    if cf_version:
+        cf_cmd += f"-{cf_version}"
+
+    check_bin(cf_cmd)
+
     if args.check:
-        ret = check(args, files)
+        ret = check(args, files, cf_cmd)
     else:
-        ret = fmt(args, files)
+        ret = fmt(args, files, cf_cmd)
 
     sys.exit(int(ret > 0))


### PR DESCRIPTION
**Context:**
`make format` (and `make format-cpp`) now accepts the version number in case `clang-format` is not installed or not satisfying the default version -- that is currently `12`. This update avoids inconsistencies between different clang-format aliases and eases trying different versions when needed. 
