### PR TITLE
Add louder warnings for CPU only use

### DIFF
--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -404,8 +404,16 @@ if not CPP_BINARY_AVAILABLE:
         _CPP_BINARY_AVAILABLE = False
 
         def __init__(self, *args, **kwargs):
+            w_msg = """
+            !!!#####################################################################################
+            !!!
+            !!! WARNING: INSUFFICIENT SUPPORT DETECTED FOR GPU DEVICE WITH `lightning.gpu`
+            !!!          DEFAULTING TO CPU DEVICE `lightning.qubit`
+            !!!
+            !!!#####################################################################################
+            """
             warn(
-                "Insufficient support detected for lightning.gpu, defaulting to lightning.qubit",
-                UserWarning,
+                w_msg,
+                RuntimeWarning,
             )
             super().__init__(*args, **kwargs)


### PR DESCRIPTION
**Context:** This improve visibility of warning message when using the CPU only fallback device.

**Description of the Change:** Improves warning visibility

**Benefits:** Makes it known the user is on CPU only device

**Possible Drawbacks:** None

**Related GitHub Issues:**
