### PR TITLE
Fix finite shots with observables needing diagonalizing gates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Release 0.24.1
+
+### Bug fixes
+
+* Ensure diagonalizing gates are applied before sampling on GPU. [(#36)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/36)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+Christina Lee, Lee James O'Riordan
+
+---
+
 # Release 0.24.0
 
 ### New features since last release

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -315,6 +315,9 @@ class LightningGPU(LightningQubit):
             return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 
         if self.shots is not None:
+            if observable.name != "PauliZ":
+                self.apply_cq(observable.diagonalizing_gates())
+                self._samples = self.generate_samples()
             # estimate the expectation value
             samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)
             return np.squeeze(np.mean(samples, axis=0))

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -321,9 +321,6 @@ class LightningGPU(LightningQubit):
             return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 
         if self.shots is not None:
-            # if observable.name != "PauliZ":
-            #    self.apply_cq(observable.diagonalizing_gates())
-            #    self._samples = self.generate_samples()
             # estimate the expectation value
             samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)
             return np.squeeze(np.mean(samples, axis=0))
@@ -369,9 +366,6 @@ class LightningGPU(LightningQubit):
 
     def var(self, observable, shot_range=None, bin_size=None):
         if self.shots is not None:
-            # if observable.name != "PauliZ":
-            #    self.apply_cq(observable.diagonalizing_gates())
-            #    self._samples = self.generate_samples()
             # estimate the var
             # Lightning doesn't support sampling yet
             samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -305,6 +305,12 @@ class LightningGPU(LightningQubit):
         jac_r[:, record_tp_rows] = jac
         return jac_r
 
+    def sample(self, observable, shot_range=None, bin_size=None):
+        if observable.name != "PauliZ":
+            self.apply_cq(observable.diagonalizing_gates())
+            self._samples = self.generate_samples()
+        return super().sample(observable, shot_range=shot_range, bin_size=bin_size)
+
     def expval(self, observable, shot_range=None, bin_size=None):
         if observable.name in [
             "Projector",
@@ -315,9 +321,9 @@ class LightningGPU(LightningQubit):
             return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 
         if self.shots is not None:
-            if observable.name != "PauliZ":
-                self.apply_cq(observable.diagonalizing_gates())
-                self._samples = self.generate_samples()
+            # if observable.name != "PauliZ":
+            #    self.apply_cq(observable.diagonalizing_gates())
+            #    self._samples = self.generate_samples()
             # estimate the expectation value
             samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)
             return np.squeeze(np.mean(samples, axis=0))
@@ -363,6 +369,9 @@ class LightningGPU(LightningQubit):
 
     def var(self, observable, shot_range=None, bin_size=None):
         if self.shots is not None:
+            # if observable.name != "PauliZ":
+            #    self.apply_cq(observable.diagonalizing_gates())
+            #    self._samples = self.generate_samples()
             # estimate the var
             # Lightning doesn't support sampling yet
             samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Fixes an issue for finite shots with non computational basis observables, where the diagonalising gates are not called. This PR ensure they are called where applicable before evaluating GPU shots.

**Description of the Change:** Ensures diagonalizing gates called where applicable for a given observable before evaluating finite shots.

**Benefits:** Fixes an issue with 0.24.0

**Possible Drawbacks:**

**Related GitHub Issues:**
