### PR TITLE
Update Lightning tag to latest_release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,24 @@
+# Release 0.26.0-dev
+
+### New features since last release
+
+### Breaking changes
+
+### Improvements
+
+### Documentation
+
+### Bug fixes
+
+* Update Lightning tag to latest_release.
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+Amintor Dusko
+
+---
 # Release 0.25.0
 
 ### New features since last release

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 * Update Lightning tag to latest_release.
+[(#51)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/51)
 
 ### Contributors
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ set(ENABLE_OPENMP ON)
 FetchContent_Declare(
     pennylane_lightning
     GIT_REPOSITORY https://github.com/PennyLaneAI/pennylane-lightning.git
-    GIT_TAG       latest
+    GIT_TAG       latest_release
 )
 FetchContent_MakeAvailable(pennylane_lightning)
 


### PR DESCRIPTION
**Context:** PennyLane Lightning changed the latest tag name to latest_release. This need to be updated here.

**Description of the Change:** Updated the respective CMake file.

**Benefits:** CMake build will work.

**Possible Drawbacks:**

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane-lightning-gpu/issues/50
