### PR TITLE
Fix statistics method due to API change

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Bug fixes
 
+* Fix statistics method to support changes in qubit device API.
+[(#55)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/55)
+
 * Update Lightning tag to latest_release.
 [(#51)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/51)
 

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -142,11 +142,11 @@ class LightningGPU(LightningQubit):
         capabilities.pop("passthru_devices", None)
         return capabilities
 
-    def statistics(self, observables, shot_range=None, bin_size=None):
+    def statistics(self, observables, shot_range=None, bin_size=None, circuit=None):
         ## Ensure D2H sync before calculating non-GPU supported operations
         if self._sync:
             self.syncD2H()
-        return super().statistics(observables, shot_range, bin_size)
+        return super().statistics(observables, shot_range, bin_size, circuit)
 
     def apply_cq(self, operations, **kwargs):
         # Skip over identity operations instead of performing


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This changes fixes the statistics method defined for `lightning.gpu` due to https://github.com/PennyLaneAI/pennylane/pull/2820 change in the `_qubit_device` API.

**Description of the Change:** Adds additional keyword arg to avoid failures in tests.

**Benefits:** `pl-device-tests` no longer fail with `lightning.gpu`

**Possible Drawbacks:**

**Related GitHub Issues:**
