### PR TITLE
Fix dropped dispatcher function calls

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Update Lightning tag to latest_release.
 [(#51)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/51)
 
-* Reintroduce dispatching support for SingleExcitation and DoubleExcitation gates in C++ layer.
+* Reintroduce dispatching support for `SingleExcitation` and `DoubleExcitation` gates in C++ layer.
 [(#56)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/56)
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,11 +13,14 @@
 * Update Lightning tag to latest_release.
 [(#51)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/51)
 
+* Reintroduce dispatching support for SingleExcitation and DoubleExcitation gates in C++ layer.
+[(#56)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/56)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko
+Amintor Dusko, Lee James O'Riordan
 
 ---
 # Release 0.25.0

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -905,39 +905,45 @@ class StateVectorCudaManaged
          }},
         {"SingleExcitation",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
-             applySingleExcitation(std::forward<decltype(wires)>(wires),
-                      std::forward<decltype(adjoint)>(adjoint),
-                      std::forward<decltype(params[0])>(params[0]));
+             applySingleExcitation(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint),
+                 std::forward<decltype(params[0])>(params[0]));
          }},
         {"SingleExcitationPlus",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
-             applySingleExcitationPlus(std::forward<decltype(wires)>(wires),
-                      std::forward<decltype(adjoint)>(adjoint),
-                      std::forward<decltype(params[0])>(params[0]));
+             applySingleExcitationPlus(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint),
+                 std::forward<decltype(params[0])>(params[0]));
          }},
         {"SingleExcitationMinus",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
-             applySingleExcitationMinus(std::forward<decltype(wires)>(wires),
-                      std::forward<decltype(adjoint)>(adjoint),
-                      std::forward<decltype(params[0])>(params[0]));
+             applySingleExcitationMinus(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint),
+                 std::forward<decltype(params[0])>(params[0]));
          }},
         {"DoubleExcitation",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
-             applyDoubleExcitation(std::forward<decltype(wires)>(wires),
-                      std::forward<decltype(adjoint)>(adjoint),
-                      std::forward<decltype(params[0])>(params[0]));
+             applyDoubleExcitation(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint),
+                 std::forward<decltype(params[0])>(params[0]));
          }},
         {"DoubleExcitationPlus",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
-             applyDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
-                      std::forward<decltype(adjoint)>(adjoint),
-                      std::forward<decltype(params[0])>(params[0]));
+             applyDoubleExcitationPlus(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint),
+                 std::forward<decltype(params[0])>(params[0]));
          }},
         {"DoubleExcitationMinus",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
-             applyDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
-                      std::forward<decltype(adjoint)>(adjoint),
-                      std::forward<decltype(params[0])>(params[0]));
+             applyDoubleExcitationMinus(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint),
+                 std::forward<decltype(params[0])>(params[0]));
          }},
         {"ControlledPhaseShift",
          [&](auto &&wires, auto &&adjoint, auto &&params) {

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -903,6 +903,42 @@ class StateVectorCudaManaged
                       std::forward<decltype(adjoint)>(adjoint),
                       std::forward<decltype(params[0])>(params[0]));
          }},
+        {"SingleExcitation",
+         [&](auto &&wires, auto &&adjoint, auto &&params) {
+             applySingleExcitation(std::forward<decltype(wires)>(wires),
+                      std::forward<decltype(adjoint)>(adjoint),
+                      std::forward<decltype(params[0])>(params[0]));
+         }},
+        {"SingleExcitationPlus",
+         [&](auto &&wires, auto &&adjoint, auto &&params) {
+             applySingleExcitationPlus(std::forward<decltype(wires)>(wires),
+                      std::forward<decltype(adjoint)>(adjoint),
+                      std::forward<decltype(params[0])>(params[0]));
+         }},
+        {"SingleExcitationMinus",
+         [&](auto &&wires, auto &&adjoint, auto &&params) {
+             applySingleExcitationMinus(std::forward<decltype(wires)>(wires),
+                      std::forward<decltype(adjoint)>(adjoint),
+                      std::forward<decltype(params[0])>(params[0]));
+         }},
+        {"DoubleExcitation",
+         [&](auto &&wires, auto &&adjoint, auto &&params) {
+             applyDoubleExcitation(std::forward<decltype(wires)>(wires),
+                      std::forward<decltype(adjoint)>(adjoint),
+                      std::forward<decltype(params[0])>(params[0]));
+         }},
+        {"DoubleExcitationPlus",
+         [&](auto &&wires, auto &&adjoint, auto &&params) {
+             applyDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
+                      std::forward<decltype(adjoint)>(adjoint),
+                      std::forward<decltype(params[0])>(params[0]));
+         }},
+        {"DoubleExcitationMinus",
+         [&](auto &&wires, auto &&adjoint, auto &&params) {
+             applyDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
+                      std::forward<decltype(adjoint)>(adjoint),
+                      std::forward<decltype(params[0])>(params[0]));
+         }},
         {"ControlledPhaseShift",
          [&](auto &&wires, auto &&adjoint, auto &&params) {
              applyControlledPhaseShift(


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** A recent merge removed the dispatcher supported Single and Double excitation gates from the CPP layer. Direct use of the gates remains, but the CPP tests fail for these gates. This PR will reintroduce the dispatch support.

**Description of the Change:** See above.

**Benefits:** Fixes the CPP tests and reintroduces direct CPP support for excitation gate dispatching.

**Possible Drawbacks:**

**Related GitHub Issues:**
