### PR TITLE
Fix for H reduction in Python layer

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,19 @@
 
 ### Contributors
 
+
+---
+# Release 0.26.2
+
+### Bug fixes
+
+* Fix reduction over batched & decomposed Hamiltonians in adjoint pipeline
+[(#64)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/64)
+
+### Contributors
+
+Lee J. O'Riordan
+
 ---
 # Release 0.26.1
 

--- a/pennylane_lightning_gpu/_serialize.py
+++ b/pennylane_lightning_gpu/_serialize.py
@@ -174,13 +174,17 @@ def _serialize_observables(tape: QuantumTape, wires_map: dict, use_csingle: bool
         list(ObservableGPU_C64 or ObservableGPU_C128): A list of observable objects compatible with the C++ backend
     """
     output = []
+    offsets = [0]
+
     for ob in tape.observables:
         ser_ob = _serialize_ob(ob, wires_map, use_csingle)
         if isinstance(ser_ob, list):
             output.extend(ser_ob)
+            offsets.append(offsets[-1] + len(ser_ob))
         else:
             output.append(ser_ob)
-    return output
+            offsets.append(offsets[-1] + 1)
+    return output, offsets
 
 
 def _serialize_ops(

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -139,7 +139,7 @@ class StateVectorCudaManaged
         const std::vector<std::size_t> tgts{wires.begin() + ctrl_offset,
                                             wires.end()};
         if (opName == "Identity") {
-            // No op
+            return;
         } else if (native_gates_.find(opName) != native_gates_.end()) {
             applyParametricPauliGate({opName}, ctrls, tgts, params.front(),
                                      adjoint);

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -14,6 +14,7 @@
 """
 Tests for the ``adjoint_jacobian`` method of LightningGPU.
 """
+import itertools as it
 import math
 import pytest
 
@@ -831,14 +832,20 @@ def test_integration_custom_wires_batching(returns):
             qml.PauliZ(custom_wires[0]) @ qml.PauliY(custom_wires[3]),
             0.5 * qml.PauliZ(custom_wires[1]),
         ),
+        (
+            0.0 * qml.PauliZ(custom_wires[0]) @ qml.PauliZ(custom_wires[1]),
+            1.0 * qml.Identity(10),
+            1.2 * qml.PauliZ(custom_wires[2]) @ qml.PauliZ(custom_wires[3]),
+        ),
     ],
 )
 def test_batching_H(returns):
     """Integration tests that compare to default.qubit for a large circuit containing parametrized
     operations and when using custom wire labels"""
 
-    dev_gpu = qml.device("lightning.gpu", wires=custom_wires, batch_obs=True)
-    dev_gpu_default = qml.device("lightning.gpu", wires=custom_wires, batch_obs=False)
+    dev_cpu = qml.device("lightning.qubit", wires=custom_wires + [10, 72])
+    dev_gpu = qml.device("lightning.gpu", wires=custom_wires + [10, 72], batch_obs=True)
+    dev_gpu_default = qml.device("lightning.gpu", wires=custom_wires + [10, 72], batch_obs=False)
 
     def circuit(params):
         circuit_ansatz(params, wires=custom_wires)
@@ -848,13 +855,82 @@ def test_batching_H(returns):
     np.random.seed(1337)
     params = np.random.rand(n_params)
 
+    qnode_cpu = qml.QNode(circuit, dev_cpu, diff_method="parameter-shift")
     qnode_gpu = qml.QNode(circuit, dev_gpu, diff_method="adjoint")
     qnode_gpu_default = qml.QNode(circuit, dev_gpu_default, diff_method="adjoint")
 
+    j_cpu = qml.jacobian(qnode_cpu)(params)
     j_gpu = qml.jacobian(qnode_gpu)(params)
     j_gpu_default = qml.jacobian(qnode_gpu_default)(params)
 
+    assert np.allclose(j_cpu, j_gpu)
     assert np.allclose(j_gpu, j_gpu_default)
+
+
+@pytest.fixture(scope="session")
+def create_xyz_file(tmp_path_factory):
+    directory = tmp_path_factory.mktemp("tmp")
+    file = directory / "h2.xyz"
+    file.write_text("""2\nH2, Unoptimized\nH  1.0 0.0 0.0\nH -1.0 0.0 0.0""")
+    yield file
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "dev_compare, batches",
+    list(it.product(["default.qubit", "lightning.qubit"], [False, True, 1, 2, 3, 4])),
+)
+def test_integration_H2_Hamiltonian(create_xyz_file, dev_compare, batches):
+    n_electrons = 2
+    np.random.seed(1337)
+
+    str_path = create_xyz_file
+    symbols, coordinates = qml.qchem.read_structure(str(str_path), outpath=str(str_path.parent))
+
+    H, qubits = qml.qchem.molecular_hamiltonian(
+        symbols,
+        coordinates,
+        method="pyscf",
+        active_electrons=n_electrons,
+        name="h2",
+        outpath=str(str_path.parent),
+    )
+    hf_state = qml.qchem.hf_state(n_electrons, qubits)
+    singles, doubles = qml.qchem.excitations(n_electrons, qubits)
+
+    # Choose different batching supports here
+    dev = qml.device("lightning.gpu", wires=qubits, batch_obs=batches)
+    dev_comp = qml.device(dev_compare, wires=qubits)
+
+    @qml.qnode(dev, diff_method="adjoint")
+    def circuit(params, excitations):
+        qml.BasisState(hf_state, wires=H.wires)
+        for i, excitation in enumerate(excitations):
+            if len(excitation) == 4:
+                qml.DoubleExcitation(params[i], wires=excitation)
+            else:
+                qml.SingleExcitation(params[i], wires=excitation)
+        return qml.expval(H)
+
+    @qml.qnode(dev_comp, diff_method="parameter-shift")
+    def circuit_compare(params, excitations):
+        qml.BasisState(hf_state, wires=H.wires)
+
+        for i, excitation in enumerate(excitations):
+            if len(excitation) == 4:
+                qml.DoubleExcitation(params[i], wires=excitation)
+            else:
+                qml.SingleExcitation(params[i], wires=excitation)
+        return qml.expval(H)
+
+    jac_func = qml.jacobian(circuit)
+    jac_func_comp = qml.jacobian(circuit_compare)
+
+    params = qml.numpy.array([0.0] * len(doubles), requires_grad=True)
+    jacs = jac_func(params, excitations=doubles)
+    jacs_comp = jac_func_comp(params, excitations=doubles)
+
+    assert np.allclose(jacs, jacs_comp)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** A recent update to support batching with `qml.expval(H)` failed to preserve the correct observable for specific decomposed ops (mixtures of native and decomposed). Here we add support to ensure reduction is performed on the required decomposed operations at the Python level, and preserves the existing compatible with `parameter-shift.

**Description of the Change:** As above.

**Benefits:** Fixes inconsistent GPU batching results for decomposed Hamiltonians.

**Possible Drawbacks:**

**Related GitHub Issues:**
