### PR TITLE
Fix void type for Databuffer

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,8 +10,12 @@
 
 ### Bug fixes
 
+* Fix void data type used in SparseSpMV
+[(#69)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/69)
+
 ### Contributors
 
+Shuli Shu
 
 ---
 # Release 0.26.2

--- a/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
@@ -546,7 +546,7 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
             CUSPARSE_SPMV_CSR_ALG1, // Can also use CUSPARSE_MV_ALG_DEFAULT
             /* size_t* */ &bufferSize))
 
-        DataBuffer<void, int> dBuffer{bufferSize, device_id, stream_id, true};
+        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id, stream_id, true};
 
         // execute SpMV
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV(
@@ -560,7 +560,7 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */
             CUSPARSE_SPMV_CSR_ALG1, // Can also use CUSPARSE_MV_ALG_DEFAULT
-            /* void* */ dBuffer.getData()))
+            /* void* */ reinterpret_cast<void *>(dBuffer.getData())))
 
         // destroy matrix/vector descriptors
         PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat))

--- a/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
@@ -561,7 +561,7 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */
             CUSPARSE_SPMV_CSR_ALG1, // Can also use CUSPARSE_MV_ALG_DEFAULT
-            /* void* */ reinterpret_cast<void *>(dBuffer.getData())))
+            /* void* */ reinterpret_cast<void *>(dBuffer.getData())));
 
         // destroy matrix/vector descriptors
         PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat))

--- a/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
@@ -546,7 +546,8 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
             CUSPARSE_SPMV_CSR_ALG1, // Can also use CUSPARSE_MV_ALG_DEFAULT
             /* size_t* */ &bufferSize))
 
-        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id, stream_id, true};
+        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id,
+                                                stream_id, true};
 
         // execute SpMV
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV(

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -852,7 +852,7 @@ class StateVectorCudaManaged
             /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
             /* void* */
             reinterpret_cast<void *>(
-                dBuffer.getData()))) // Can also use
+                dBuffer.getData()))); // Can also use
                                      // CUSPARSE_MV_ALG_DEFAULT
 
         // destroy matrix/vector descriptors

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -836,7 +836,8 @@ class StateVectorCudaManaged
             /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
             /* size_t* */ &bufferSize)) // Can also use CUSPARSE_MV_ALG_DEFAULT
 
-        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id, stream_id, true};
+        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id,
+                                                stream_id, true};
 
         // execute SpMV
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV(
@@ -849,8 +850,10 @@ class StateVectorCudaManaged
             /* cusparseDnVecDescr_t */ vecY,
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
-            /* void* */ reinterpret_cast<void *>(dBuffer.getData()))) // Can also use
-                                            // CUSPARSE_MV_ALG_DEFAULT
+            /* void* */
+            reinterpret_cast<void *>(
+                dBuffer.getData()))) // Can also use
+                                     // CUSPARSE_MV_ALG_DEFAULT
 
         // destroy matrix/vector descriptors
         PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat))

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -836,7 +836,7 @@ class StateVectorCudaManaged
             /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
             /* size_t* */ &bufferSize)) // Can also use CUSPARSE_MV_ALG_DEFAULT
 
-        DataBuffer<void, int> dBuffer{bufferSize, device_id, stream_id, true};
+        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id, stream_id, true};
 
         // execute SpMV
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV(
@@ -849,7 +849,7 @@ class StateVectorCudaManaged
             /* cusparseDnVecDescr_t */ vecY,
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
-            /* void* */ dBuffer.getData())) // Can also use
+            /* void* */ reinterpret_cast<void *>(dBuffer.getData()))) // Can also use
                                             // CUSPARSE_MV_ALG_DEFAULT
 
         // destroy matrix/vector descriptors

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -853,7 +853,7 @@ class StateVectorCudaManaged
             /* void* */
             reinterpret_cast<void *>(
                 dBuffer.getData()))); // Can also use
-                                     // CUSPARSE_MV_ALG_DEFAULT
+                                      // CUSPARSE_MV_ALG_DEFAULT
 
         // destroy matrix/vector descriptors
         PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat))

--- a/pennylane_lightning_gpu/src/util/DataBuffer.hpp
+++ b/pennylane_lightning_gpu/src/util/DataBuffer.hpp
@@ -32,10 +32,7 @@ template <class GPUDataT, class DevTagT = int> class DataBuffer {
                cudaStream_t stream_id = 0, bool alloc_memory = true)
         : length_{length}, dev_tag_{device_id, stream_id}, gpu_buffer_{
                                                                nullptr} {
-        if constexpr (std::is_void<GPUDataT>::value) {
-            dev_tag_.refresh();
-            PL_CUDA_IS_SUCCESS(cudaMalloc(&gpu_buffer_, length));
-        } else if (alloc_memory && (length > 0)) {
+	if (alloc_memory && (length > 0)) {
             dev_tag_.refresh();
             PL_CUDA_IS_SUCCESS(
                 cudaMalloc(reinterpret_cast<void **>(&gpu_buffer_),

--- a/pennylane_lightning_gpu/src/util/DataBuffer.hpp
+++ b/pennylane_lightning_gpu/src/util/DataBuffer.hpp
@@ -32,7 +32,7 @@ template <class GPUDataT, class DevTagT = int> class DataBuffer {
                cudaStream_t stream_id = 0, bool alloc_memory = true)
         : length_{length}, dev_tag_{device_id, stream_id}, gpu_buffer_{
                                                                nullptr} {
-	if (alloc_memory && (length > 0)) {
+        if (alloc_memory && (length > 0)) {
             dev_tag_.refresh();
             PL_CUDA_IS_SUCCESS(
                 cudaMalloc(reinterpret_cast<void **>(&gpu_buffer_),


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

This PR brings the bug fix to avoid using `void` as a template parameter for the `DataBuffer` type when declaring memory buffer for the `cusparseSpMV` API. Without this fix, there will be a `forming reference to void` error when adding a new method to the `DataBuffer` class with a `GPUDataT` type argument.

**Description of the Change:**

**Benefits:**

It will be safer when extending the `DataBuffer` class with new methods.

**Possible Drawbacks:**

**Related GitHub Issues:**
