### PR TITLE
Enable the generation of wheels for python 3.11 and upgrade python on CI/CD workflows to 3.8

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* Enable building of wheels for python 3.11 and upgrade python on CI/CD workflows to 3.8.
+* Enable building of python 3.11 wheels and upgrade python on CI/CD workflows to 3.8.
 [(#71)](https://github.com/PennyLaneAI/pennylane-lightning/pull/71)
 
 ### Breaking changes
@@ -16,6 +16,7 @@
 ### Contributors
 
 Amintor Dusko
+
 ---
 # Release 0.26.2
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+* Enable building of wheels for python 3.11 and upgrade python on CI/CD workflows to 3.8.
+[(#71)](https://github.com/PennyLaneAI/pennylane-lightning/pull/71)
+
 ### Breaking changes
 
 ### Improvements
@@ -12,7 +15,7 @@
 
 ### Contributors
 
-
+Amintor Dusko
 ---
 # Release 0.26.2
 
@@ -42,9 +45,9 @@ Lee J. O'Riordan
 
 ### New features since last release
 
-* Added native support for expval(H) in adjoint method. [(#52)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/52) 
+* Added native support for expval(H) in adjoint method. [(#52)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/52)
 
-* Added cuSparse SpMV in expval(H) calculations. [(#52)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/52) 
+* Added cuSparse SpMV in expval(H) calculations. [(#52)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/52)
 
 ### Breaking changes
 
@@ -223,7 +226,7 @@ def circuit(weights):
     StronglyEntanglingLayers(weights, wires=list(range(n_wires)))
     return [qml.expval(qml.PauliZ(i)) for i in range(n_wires)]
 
-params = np.random.random(StronglyEntanglingLayers.shape(n_layers=n_layers, n_wires=n_wires)) 
+params = np.random.random(StronglyEntanglingLayers.shape(n_layers=n_layers, n_wires=n_wires))
 result = circuit(params)
 ```
 

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -7,13 +7,13 @@ on:
   pull_request:
 
 env:
-  CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+  CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-* cp311-*'
   CIBW_BUILD_FRONTEND: "pip"
   CIBW_SKIP: "*-musllinux*"
 
   # Python build settings
   CIBW_BEFORE_BUILD: |
-    python -m pip install pybind11 ninja cmake auditwheel && python -m pip install --no-deps cuquantum 
+    python -m pip install pybind11 ninja cmake auditwheel && python -m pip install --no-deps cuquantum
     yum install -y gcc gcc-c++
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
     yum clean all
@@ -37,16 +37,17 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - name: Checkout pennyLane-lightning-gpu
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
+        name: Install Python
         with:
-          python-version: 3.7
+          python-version: '3.8'
 
       - name: Install dependencies
         run:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ include(FetchContent)
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.9.1
+    GIT_TAG        v2.10.1
 )
 FetchContent_MakeAvailable(pybind11)
 
@@ -190,7 +190,7 @@ if(DISABLE_CUDA_SAFETY)
 endif()
 
 if(ENABLE_WARNINGS)
-    target_compile_options(pennylane_lightning_gpu INTERFACE 
+    target_compile_options(pennylane_lightning_gpu INTERFACE
         $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror>
     )
 endif()

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.27.0-dev0"
+__version__ = "0.27.0-dev1"


### PR DESCRIPTION
**Context:** This PR enables the generation of wheels for python 3.11. 
Also, we are updating the python version of CI/CD workflows from 3.7 to 3.8.

**Description of the Change:**

**Benefits:**
- Provide wheels for python 3.11.
- Faster CI/CD workflows with python 3.8.

**Possible Drawbacks:**

**Related GitHub Issues:**
