### PR TITLE
Add native SparseH support for adjoint

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,7 +22,7 @@
       return qml.expval(H)
   ```
 
-  For the new `qml.SparseHamiltonian` the above script becomes:
+  For the new `qml.SparseHamiltonian` support, the above script becomes:
   ```python
   dev = qml.device("lightning.gpu", wires=num_wires)
   H = sum([0.5*(i+1)*(qml.PauliZ(i)@qml.PauliZ(i+1)) for i in range(0, num_wires-1, 2)])

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
   [(#72)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/72)
 
   This support allows users to explicitly make use of `qml.SparseHamiltonian` in expectation value calculations, and ensures the gradients can be taken efficiently. 
-  A user can now explicitly decide whether to decompose the Hamiltonian into separate Pauli-words, with evaluations happening over multiple GPUs, or convert the Hamiltonian directly to a sparse representation for evaluation on a single GPU. Depending on the Hamiltionian structure, a user may benefit from one method or the other.
+  A user can now explicitly decide whether to decompose the Hamiltonian into separate Pauli-words, with evaluations happening over multiple GPUs, or convert the Hamiltonian directly to a sparse representation for evaluation on a single GPU. Depending on the Hamiltonian structure, a user may benefit from one method or the other.
 
   The work-flow for decomposing a Hamiltonian is as:
   ```python

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ### New features since last release
 
+* Explicit support for `qml.SparseHamiltonian` using the adjoint gradient method. 
+  [(#72)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/72)
+
+  This support allows users to explicitly make use of `qml.SparseHamiltonian` in expectation value calculations, and ensures the gradients can be taken efficiently. 
+  A user can now explicitly decide whether to decompose the Hamiltonian into separate Pauli-words, with evaluations happening over multiple GPUs, or convert the Hamiltonian directly to a sparse representation for evaluation on a single GPU. Depending on the Hamiltionian structure, a user may benefit from one method or the other.
+
+  The work-flow for decomposing a Hamiltonian is as:
+  ```python
+  obs_per_gpu = 1
+  dev = qml.device("lightning.gpu", wires=num_wires, batch_obs=obs_per_gpu)
+
+  H = sum([0.5*(i+1)*(qml.PauliZ(i)@qml.PauliZ(i+1)) for i in range(0, num_wires-1, 2)])
+
+  @qml.qnode(dev, diff_method="adjoint")
+  def circuit(params):
+      for i in range(num_wires):
+          qml.RX(params[i], i)
+      return qml.expval(H)
+  ```
+
+  For the new `qml.SparseHamiltonian` the above script becomes:
+  ```python
+  dev = qml.device("lightning.gpu", wires=num_wires)
+  H = sum([0.5*(i+1)*(qml.PauliZ(i)@qml.PauliZ(i+1)) for i in range(0, num_wires-1, 2)])
+  H_sparse_matrix = qml.utils.sparse_hamiltonian(H, wires=range(num_wires))
+
+  SpH = qml.SparseHamiltonian(H_sparse_matrix, wires=range(num_wires))
+
+  @qml.qnode(dev, diff_method="adjoint")
+  def circuit(params):
+      for i in range(num_wires):
+          qml.RX(params[i], i)
+      return qml.expval(SpH)
+  ```
+
 * Enable building of python 3.11 wheels and upgrade python on CI/CD workflows to 3.8.
 [(#71)](https://github.com/PennyLaneAI/pennylane-lightning/pull/71)
 
@@ -18,7 +53,7 @@
 
 ### Contributors
 
-Amintor Dusko, Shuli Shu
+Amintor Dusko, Lee J. O'Riordan, Shuli Shu
 
 ---
 # Release 0.26.2

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,7 @@
   This support allows users to explicitly make use of `qml.SparseHamiltonian` in expectation value calculations, and ensures the gradients can be taken efficiently. 
   A user can now explicitly decide whether to decompose the Hamiltonian into separate Pauli-words, with evaluations happening over multiple GPUs, or convert the Hamiltonian directly to a sparse representation for evaluation on a single GPU. Depending on the Hamiltonian structure, a user may benefit from one method or the other.
 
-  The work-flow for decomposing a Hamiltonian is as:
+  The workflow for decomposing a Hamiltonian is as:
   ```python
   obs_per_gpu = 1
   dev = qml.device("lightning.gpu", wires=num_wires, batch_obs=obs_per_gpu)

--- a/pennylane_lightning_gpu/_serialize.py
+++ b/pennylane_lightning_gpu/_serialize.py
@@ -151,9 +151,7 @@ def _serialize_ob(ob, wires_map, use_csingle):
     elif ob.name == "Hamiltonian":
         return _serialize_hamiltonian(ob, wires_map, use_csingle)
     elif ob.name == "SparseHamiltonian":
-        raise TypeError(
-            f"SparseHamiltonian observables are not currently supported for adjoint differentiation. Please use `qml.Hamiltonian`."
-        )
+        return _serialize_sparsehamiltonian(ob, wires_map, use_csingle)
     elif ob.name == "Hermitian":
         raise TypeError(
             f"Hermitian observables are not currently supported for adjoint differentiation. Please use Pauli-words only."

--- a/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
@@ -196,7 +196,7 @@ template <typename T> class TensorProdObsGPU final : public ObservableGPU<T> {
      * @param arg Arguments perfect forwarded to vector of observables.
      */
     template <typename... Ts>
-    explicit TensorProdObsGPU(Ts &&... arg) : obs_{std::forward<Ts>(arg)...} {
+    explicit TensorProdObsGPU(Ts &&...arg) : obs_{std::forward<Ts>(arg)...} {
         std::unordered_set<size_t> wires;
 
         for (const auto &ob : obs_) {

--- a/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
@@ -452,6 +452,8 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
      *
      */
     void applyInPlace(StateVectorCudaManaged<T> &sv) const override {
+        PL_ABORT_IF_NOT(wires_.size() == sv.getNumQubits(),
+                        "SparseH wire count does not match state-vector size");
         using CFP_t = typename StateVectorCudaManaged<T>::CFP_t;
 
         const std::size_t nIndexBits = sv.getNumQubits();

--- a/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/ObservablesGPU.hpp
@@ -196,7 +196,7 @@ template <typename T> class TensorProdObsGPU final : public ObservableGPU<T> {
      * @param arg Arguments perfect forwarded to vector of observables.
      */
     template <typename... Ts>
-    explicit TensorProdObsGPU(Ts &&...arg) : obs_{std::forward<Ts>(arg)...} {
+    explicit TensorProdObsGPU(Ts &&... arg) : obs_{std::forward<Ts>(arg)...} {
         std::unordered_set<size_t> wires;
 
         for (const auto &ob : obs_) {
@@ -446,12 +446,16 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
                                         std::move(arg3), std::move(arg4)});
     }
 
-    // to work with
+    /**
+     * @brief Updates the statevector SV:->SV', where SV' = a*H*SV, and where H
+     * is a sparse Hamiltonian.
+     *
+     */
     void applyInPlace(StateVectorCudaManaged<T> &sv) const override {
         using CFP_t = typename StateVectorCudaManaged<T>::CFP_t;
 
-        const auto nIndexBits = sv.getNumQubits();
-        const auto length = 1 << nIndexBits;
+        const std::size_t nIndexBits = sv.getNumQubits();
+        const std::size_t length = 1 << nIndexBits;
         const int64_t num_rows = static_cast<int64_t>(
             offsets_.size() -
             1); // int64_t is required for num_rows by cusparseCreateCsr
@@ -466,22 +470,18 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
         auto device_id = sv.getDataBuffer().getDevTag().getDeviceID();
         auto stream_id = sv.getDataBuffer().getDevTag().getStreamID();
 
-        DataBuffer<IdxT, int> d_csrOffsets{
-            static_cast<std::size_t>(offsets_.size()), device_id, stream_id,
-            true};
-        DataBuffer<IdxT, int> d_columns{
-            static_cast<std::size_t>(indices_.size()), device_id, stream_id,
-            true};
-        DataBuffer<CFP_t, int> d_values{static_cast<std::size_t>(data_.size()),
-                                        device_id, stream_id, true};
-        DataBuffer<CFP_t, int> d_tmp{static_cast<std::size_t>(length),
-                                     device_id, stream_id, true};
+        // clang-format off
+        DataBuffer<IdxT> H_csrOffsets  { offsets_.size(), device_id, stream_id, true};
+        DataBuffer<IdxT> H_columns     { indices_.size(), device_id, stream_id, true};
+        DataBuffer<CFP_t> H_values     { data_.size(),    device_id, stream_id, true};
 
-        d_csrOffsets.CopyHostDataToGpu(offsets_.data(),
-                                       d_csrOffsets.getLength(), false);
-        d_columns.CopyHostDataToGpu(indices_.data(), d_columns.getLength(),
-                                    false);
-        d_values.CopyHostDataToGpu(data_.data(), d_values.getLength(), false);
+        // Transfer ownership after state update to StateVectorCudaManaged
+        std::unique_ptr<DataBuffer<CFP_t>> d_sv_prime = std::make_unique<DataBuffer<CFP_t>>(length, device_id, stream_id, true);
+
+        H_csrOffsets.CopyHostDataToGpu( offsets_.data(), H_csrOffsets.getLength(), false);
+        H_columns.CopyHostDataToGpu(    indices_.data(), H_columns.getLength(),    false);
+        H_values.CopyHostDataToGpu(     data_.data(),    H_values.getLength(),     false);
+        // clang-format on
 
         cudaDataType_t data_type;
         cusparseIndexType_t compute_type;
@@ -497,77 +497,79 @@ class SparseHamiltonianGPU final : public ObservableGPU<T> {
 
         // CUSPARSE APIs
         cusparseHandle_t handle = nullptr;
-        cusparseSpMatDescr_t mat;
-        cusparseDnVecDescr_t vecX, vecY;
+        cusparseSpMatDescr_t sparseH_descriptor;
+        cusparseDnVecDescr_t sv_descriptor, sv_prime_descriptor;
 
         size_t bufferSize = 0;
 
-        PL_CUSPARSE_IS_SUCCESS(cusparseCreate(&handle))
+        PL_CUSPARSE_IS_SUCCESS(cusparseCreate(&handle));
 
-        // Create sparse matrix A in CSR format
+        // Create sparse matrix descriptor for H in CSR format
         PL_CUSPARSE_IS_SUCCESS(cusparseCreateCsr(
-            /* cusparseSpMatDescr_t* */ &mat,
+            /* cusparseSpMatDescr_t* */ &sparseH_descriptor,
             /* int64_t */ num_rows,
             /* int64_t */ num_cols,
             /* int64_t */ nnz,
-            /* void* */ d_csrOffsets.getData(),
-            /* void* */ d_columns.getData(),
-            /* void* */ d_values.getData(),
+            /* void* */ H_csrOffsets.getData(),
+            /* void* */ H_columns.getData(),
+            /* void* */ H_values.getData(),
             /* cusparseIndexType_t */ compute_type,
             /* cusparseIndexType_t */ compute_type,
             /* cusparseIndexBase_t */ CUSPARSE_INDEX_BASE_ZERO,
-            /* cudaDataType */ data_type))
+            /* cudaDataType */ data_type));
 
-        // Create dense vector X
+        // Create dense statevector descriptor
         PL_CUSPARSE_IS_SUCCESS(cusparseCreateDnVec(
-            /* cusparseDnVecDescr_t* */ &vecX,
+            /* cusparseDnVecDescr_t* */ &sv_descriptor,
             /* int64_t */ num_cols,
             /* void* */ sv.getData(),
-            /* cudaDataType */ data_type))
+            /* cudaDataType */ data_type));
 
-        // Create dense vector y
+        // Create dense statevector prime descriptor
         PL_CUSPARSE_IS_SUCCESS(cusparseCreateDnVec(
-            /* cusparseDnVecDescr_t* */ &vecY,
+            /* cusparseDnVecDescr_t* */ &sv_prime_descriptor,
             /* int64_t */ num_rows,
-            /* void* */ sv.getData(),
-            /* cudaDataType */ data_type))
+            /* void* */ d_sv_prime->getData(),
+            /* cudaDataType */ data_type));
 
         // allocate an external buffer if needed
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV_bufferSize(
             /* cusparseHandle_t */ handle,
             /* cusparseOperation_t */ CUSPARSE_OPERATION_NON_TRANSPOSE,
             /* const void* */ &alpha,
-            /* cusparseSpMatDescr_t */ mat,
-            /* cusparseDnVecDescr_t */ vecX,
+            /* cusparseSpMatDescr_t */ sparseH_descriptor,
+            /* cusparseDnVecDescr_t */ sv_descriptor,
             /* const void* */ &beta,
-            /* cusparseDnVecDescr_t */ vecY,
+            /* cusparseDnVecDescr_t */ sv_prime_descriptor,
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */
             CUSPARSE_SPMV_CSR_ALG1, // Can also use CUSPARSE_MV_ALG_DEFAULT
-            /* size_t* */ &bufferSize))
+            /* size_t* */ &bufferSize));
 
-        DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id,
-                                                stream_id, true};
+        DataBuffer<cudaDataType_t> dBuffer{bufferSize, device_id, stream_id,
+                                           true};
 
         // execute SpMV
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV(
             /* cusparseHandle_t */ handle,
             /* cusparseOperation_t */ CUSPARSE_OPERATION_NON_TRANSPOSE,
             /* const void* */ &alpha,
-            /* cusparseSpMatDescr_t */ mat,
-            /* cusparseDnVecDescr_t */ vecX,
+            /* cusparseSpMatDescr_t */ sparseH_descriptor,
+            /* cusparseDnVecDescr_t */ sv_descriptor,
             /* const void* */ &beta,
-            /* cusparseDnVecDescr_t */ vecY,
+            /* cusparseDnVecDescr_t */ sv_prime_descriptor,
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */
-            CUSPARSE_SPMV_CSR_ALG1, // Can also use CUSPARSE_MV_ALG_DEFAULT
+            CUSPARSE_MV_ALG_DEFAULT,
             /* void* */ reinterpret_cast<void *>(dBuffer.getData())));
 
         // destroy matrix/vector descriptors
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat))
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(vecX))
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(vecY))
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroy(handle))
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(sparseH_descriptor));
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(sv_descriptor));
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(sv_prime_descriptor));
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroy(handle));
+
+        sv.updateData(std::move(d_sv_prime));
     }
 
     [[nodiscard]] auto getObsName() const -> std::string override {

--- a/pennylane_lightning_gpu/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_gpu/src/bindings/Bindings.cpp
@@ -510,8 +510,17 @@ void StateVectorCudaManaged_class_bindings(py::module &m) {
                      strides /* strides for each axis     */
                      ));
              })
-        .def("DeviceToDevice", &StateVectorCudaManaged<PrecisionT>::updateData,
-             "Synchronize data from another GPU device to current device.")
+        //.def("DeviceToDevice",
+        //&StateVectorCudaManaged<PrecisionT>::updateData,
+        //     "Synchronize data from another GPU device to current device.")
+
+        .def(
+            "DeviceToDevice",
+            [](StateVectorCudaManaged<PrecisionT> &sv,
+               const StateVectorCudaManaged<PrecisionT> &other,
+               bool async) { sv.updateData(other, async); },
+            "Synchronize data from another GPU device to current device.")
+
         .def("DeviceToHost",
              py::overload_cast<StateVectorManagedCPU<PrecisionT> &, bool>(
                  &StateVectorCudaManaged<PrecisionT>::CopyGpuDataToHost,

--- a/pennylane_lightning_gpu/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_gpu/src/bindings/Bindings.cpp
@@ -510,17 +510,12 @@ void StateVectorCudaManaged_class_bindings(py::module &m) {
                      strides /* strides for each axis     */
                      ));
              })
-        //.def("DeviceToDevice",
-        //&StateVectorCudaManaged<PrecisionT>::updateData,
-        //     "Synchronize data from another GPU device to current device.")
-
         .def(
             "DeviceToDevice",
             [](StateVectorCudaManaged<PrecisionT> &sv,
                const StateVectorCudaManaged<PrecisionT> &other,
                bool async) { sv.updateData(other, async); },
             "Synchronize data from another GPU device to current device.")
-
         .def("DeviceToHost",
              py::overload_cast<StateVectorManagedCPU<PrecisionT> &, bool>(
                  &StateVectorCudaManaged<PrecisionT>::CopyGpuDataToHost,

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaBase.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaBase.hpp
@@ -212,6 +212,15 @@ class StateVectorCudaBase : public StateVectorBase<Precision, Derived> {
     }
 
     /**
+     * @brief Move and replace DataBuffer for statevector.
+     *
+     * @param other Source data to copy from.
+     */
+    void updateData(std::unique_ptr<CUDA::DataBuffer<CFP_t>> &&other) {
+        data_buffer_ = std::move(other);
+    }
+
+    /**
      * @brief Initialize the statevector data to the |0...0> state
      *
      */

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -793,7 +793,7 @@ class StateVectorCudaManaged
 
         size_t bufferSize = 0;
 
-        PL_CUSPARSE_IS_SUCCESS(cusparseCreate(&handle))
+        PL_CUSPARSE_IS_SUCCESS(cusparseCreate(&handle));
 
         // Create sparse matrix A in CSR format
         PL_CUSPARSE_IS_SUCCESS(cusparseCreateCsr(
@@ -807,21 +807,21 @@ class StateVectorCudaManaged
             /* cusparseIndexType_t */ compute_type,
             /* cusparseIndexType_t */ compute_type,
             /* cusparseIndexBase_t */ CUSPARSE_INDEX_BASE_ZERO,
-            /* cudaDataType */ data_type))
+            /* cudaDataType */ data_type));
 
         // Create dense vector X
         PL_CUSPARSE_IS_SUCCESS(cusparseCreateDnVec(
             /* cusparseDnVecDescr_t* */ &vecX,
             /* int64_t */ num_cols,
             /* void* */ BaseType::getData(),
-            /* cudaDataType */ data_type))
+            /* cudaDataType */ data_type));
 
         // Create dense vector y
         PL_CUSPARSE_IS_SUCCESS(cusparseCreateDnVec(
             /* cusparseDnVecDescr_t* */ &vecY,
             /* int64_t */ num_rows,
             /* void* */ d_tmp.getData(),
-            /* cudaDataType */ data_type))
+            /* cudaDataType */ data_type));
 
         // allocate an external buffer if needed
         PL_CUSPARSE_IS_SUCCESS(cusparseSpMV_bufferSize(
@@ -834,7 +834,7 @@ class StateVectorCudaManaged
             /* cusparseDnVecDescr_t */ vecY,
             /* cudaDataType */ data_type,
             /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
-            /* size_t* */ &bufferSize)) // Can also use CUSPARSE_MV_ALG_DEFAULT
+            /* size_t* */ &bufferSize)); // Can also use CUSPARSE_MV_ALG_DEFAULT
 
         DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id,
                                                 stream_id, true};
@@ -856,10 +856,10 @@ class StateVectorCudaManaged
                                       // CUSPARSE_MV_ALG_DEFAULT
 
         // destroy matrix/vector descriptors
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat))
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(vecX))
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(vecY))
-        PL_CUSPARSE_IS_SUCCESS(cusparseDestroy(handle))
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat));
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(vecX));
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroyDnVec(vecY));
+        PL_CUSPARSE_IS_SUCCESS(cusparseDestroy(handle));
 
         expect = innerProdC_CUDA(BaseType::getData(), d_tmp.getData(),
                                  BaseType::getLength(), device_id, stream_id)

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -833,8 +833,8 @@ class StateVectorCudaManaged
             /* const void* */ &beta,
             /* cusparseDnVecDescr_t */ vecY,
             /* cudaDataType */ data_type,
-            /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
-            /* size_t* */ &bufferSize)); // Can also use CUSPARSE_MV_ALG_DEFAULT
+            /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_ALG_DEFAULT,
+            /* size_t* */ &bufferSize));
 
         DataBuffer<cudaDataType_t, int> dBuffer{bufferSize, device_id,
                                                 stream_id, true};
@@ -849,11 +849,9 @@ class StateVectorCudaManaged
             /* const void* */ &beta,
             /* cusparseDnVecDescr_t */ vecY,
             /* cudaDataType */ data_type,
-            /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_CSR_ALG1,
+            /* cusparseSpMVAlg_t */ CUSPARSE_SPMV_ALG_DEFAULT,
             /* void* */
-            reinterpret_cast<void *>(
-                dBuffer.getData()))); // Can also use
-                                      // CUSPARSE_MV_ALG_DEFAULT
+            reinterpret_cast<void *>(dBuffer.getData())));
 
         // destroy matrix/vector descriptors
         PL_CUSPARSE_IS_SUCCESS(cusparseDestroySpMat(mat));

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -1022,11 +1022,12 @@ def test_fail_adjoint_mixed_Hamiltonian_Hermitian(returns):
         ),
     ],
 )
-def test_fail_adjoint_SparseHamiltonian(returns):
+def test_adjoint_SparseHamiltonian(returns):
     """Integration tests that compare to default.qubit for a large circuit containing parametrized
     operations and when using custom wire labels"""
 
     dev_gpu = qml.device("lightning.gpu", wires=custom_wires)
+    dev_cpu = qml.device("default.qubit", wires=custom_wires)
 
     def circuit(params):
         circuit_ansatz(params, wires=custom_wires)
@@ -1037,9 +1038,9 @@ def test_fail_adjoint_SparseHamiltonian(returns):
     params = np.random.rand(n_params)
 
     qnode_gpu = qml.QNode(circuit, dev_gpu, diff_method="adjoint")
+    qnode_cpu = qml.QNode(circuit, dev_cpu, diff_method="parameter-shift")
 
-    with pytest.raises(
-        TypeError,
-        match="SparseHamiltonian observables are not currently supported",
-    ):
-        j_gpu = qml.jacobian(qnode_gpu)(params)
+    j_gpu = qml.jacobian(qnode_gpu)(params)
+    j_cpu = qml.jacobian(qnode_cpu)(params)
+
+    assert np.allclose(j_cpu, j_gpu)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -1004,19 +1004,22 @@ def test_fail_adjoint_mixed_Hamiltonian_Hermitian(returns):
     [
         qml.SparseHamiltonian(
             qml.utils.sparse_hamiltonian(
-                0.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])
+                0.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1]),
+                wires=custom_wires,
             ),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
             qml.utils.sparse_hamiltonian(
-                2 * qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])
+                2 * qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0]),
+                wires=custom_wires,
             ),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
             qml.utils.sparse_hamiltonian(
-                1.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])
+                1.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2]),
+                wires=custom_wires,
             ),
             wires=custom_wires,
         ),


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** For large Hamiltonians, the batched decomposition and native dense supports may introduce too many overheads when evaluating the gradients relative to a given Pauli word. This PR adds support to natively pass a `qml.SparseHamiltonian` object to the adjoint diff pipeline, and evaluate gradients nativbely on the GPU. This skips the decomposition and eval pipeline, and can offer significant benefits for workloads with 100+ Pauli-words, at the cost of generating the sparse Hamiltonian up-front.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
