### PR TITLE
Pin builder and support to CUDA 11.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -64,6 +64,9 @@ and change `lightning.gpu` to inherit from `QubitDevice` instead of `LightningQu
 
 ### Bug fixes
 
+* Fix wheel-builder to pin CUDA version to 11.8 instead of latest.
+[(#83)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/83)
+
 * Pin CMake to 3.24.x in wheel-builder to avoid Python not found error in CMake 3.25.
 [(#75)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/75)
 

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -61,7 +61,7 @@ jobs:
             python -m pip install --no-deps cuquantum
             yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
             yum clean all
-            yum -y install cuda git openssh wget
+            yum -y install cuda-11-8 git openssh wget
 
           # ensure nvcc is available
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/cuda/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:$(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -58,7 +58,7 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             python -m pip install ninja cmake~=3.24.3 auditwheel
-            python -m pip install --no-deps cuquantum
+            python -m pip install custatevec-cu11
             yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
             yum clean all
             yum -y install cuda-11-8 git openssh wget


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** LightningGPU and cuQuantum currently only support CUDA 11. The install instructions for CUDA previously pulled in the latest version, which defaulted to 11 until today. As a result, builds are failing for Python wheels. This PR pins the CUDA version to the latest 11.x release of 11.8

**Description of the Change:** As above.

**Benefits:** Fixes current build failures.

**Possible Drawbacks:** Will require update for supporting CUDA 11 and 12 in future.

**Related GitHub Issues:**
