### PR TITLE
add header "unordered_map" to util/cuda_helpers.hpp

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,14 +10,14 @@
 
 ### Bug fixes
 
-* add header "unordered_map" to util/cuda_helpers.hpp [(#86)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/86)
+* Add header `unordered_map` to `util/cuda_helpers.hpp`.
+ [(#86)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/86)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
 Feng Wang
-
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* add header "unordered_map" to util/cuda_helpers.hpp [(#86)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/86)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Feng Wang
+
 
 ---
 

--- a/pennylane_lightning_gpu/src/util/cuda_helpers.hpp
+++ b/pennylane_lightning_gpu/src/util/cuda_helpers.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <numeric>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 #include <cuComplex.h>


### PR DESCRIPTION
Prevent compilation error for g++-11

**Context:**
When compiling this repo in a docker `pytorch/pytorch`:
* ubuntu version 18.04
* gcc version 11 (installed from ppa:ubuntu-toolchain-r/test)
* nvcc/CUDA version 11.7

This line
https://github.com/PennyLaneAI/pennylane-lightning-gpu/blob/1efbe63881aeed132e3f38d31f5ad4bf26186722/pennylane_lightning_gpu/src/util/cuda_helpers.hpp#L589 fails to compile.

**Description of the Change:**

Add missing header `<unordered_map>` to util/cuda_helpers.hpp

**Benefits:**

The above file compiles.

**Possible Drawbacks:**

**Related GitHub Issues:**
