### PR TITLE
Downgrade CUDA compiler for releases

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,15 +1,11 @@
-# Release 0.29.0-dev
-
-### New features since last release
-
-### Breaking changes
-
-### Improvements
-
-### Documentation
+# Release 0.28.1
 
 ### Bug fixes
 
+* Downgrade CUDA compiler for wheels to avoid compatibility issues with older runtimes.
+ [(#87)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/87)
+
+### Contributors
 * Add header `unordered_map` to `util/cuda_helpers.hpp`.
  [(#86)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/86)
 
@@ -17,7 +13,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Feng Wang
+Lee James O'Riordan, Feng Wang
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Release 0.29.0-dev
+
+### New features since last release
+
+### Breaking changes
+
+### Improvements
+
+### Documentation
+
+### Bug fixes
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+---
+
 # Release 0.28.1
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Downgrade CUDA compiler for wheels to avoid compatibility issues with older runtimes.
  [(#87)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/87)
 
-### Contributors
 * Add header `unordered_map` to `util/cuda_helpers.hpp`.
  [(#86)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/86)
 

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -61,7 +61,7 @@ jobs:
             python -m pip install custatevec-cu11
             yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo -y
             yum clean all
-            yum -y install cuda-11-8 git openssh wget
+            yum -y install cuda-11-5 git openssh wget
 
           # ensure nvcc is available
           CIBW_ENVIRONMENT: PATH=$PATH:/usr/local/cuda/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:$(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.1-rc0"
+__version__ = "0.29.0-dev0"

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.0"
+__version__ = "0.28.1-rc0"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** The current version of `lightning.gpu` is compiled with the latest release of the CUDA 11.x branch. This was pinned to 11.8 to avoid conflicting with the release of CUDA 12. However, for systems that have older versions of CUDA 11 installed (11.7 and earlier) builds with this modern version can fail without following the explicit steps for managing backward/forward compatibility as listed by https://docs.nvidia.com/deploy/cuda-compatibility/index.html#forward-compatibility-title As such, for systems where users cannot upgrade CUDA, or are unable to make use of the compat libraries, the package will fail to make calls to the CUDA runtime. As noticed by https://discuss.pennylane.ai/t/lightning-gpu-not-working/2430/3 `cudaMalloc` failures were observed. The goal of this PR is to ensure a compatible build of the LightningGPU Python module for CUDA 11.5 and newer.

**Description of the Change:** Downgrades CUDA compiler and libraries to 11.5 for wheel builds.

**Benefits:** Ensures compatibility with CUDA 11.5 and newer.

**Possible Drawbacks:** Potential performance degradation in compiled kernels. Should be safe to ignore.

**Related GitHub Issues:** https://discuss.pennylane.ai/t/lightning-gpu-not-working/2430/3
