### PR TITLE
Change inv method to adjoint method in unit tests

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* Remove `inv()` method in Python unit tests to be aligned with recent change in Pennylane and avoid CI failures.
+ [(#88)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/88)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Shuli Shu
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-* Change `inv()` method to `qml.adjoint()` method in Python unit tests to be aligned with recent change in Pennylane and avoid CI failures.
+* Update `inv()` to `qml.adjoint()` in Python tests following recent changes in Pennylane.
  [(#88)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/88)
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### Improvements
 
+* Change `inv()` method to `qml.adjoint()` method in Python unit tests to be aligned with recent change in Pennylane and avoid CI failures.
+ [(#88)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/88)
 ### Documentation
 
 ### Bug fixes
 
-* Remove `inv()` method in Python unit tests to be aligned with recent change in Pennylane and avoid CI failures.
- [(#88)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/88)
 
 ### Contributors
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,7 +298,7 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
-            qml.adjoint(qml.RX(params[2], wires=wires[2]), lazy=False)
+            qml.adjoint(qml.RY(0.5, wires=1), lazy=False)
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,7 +298,6 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
-            qml.RY(0.5, wires=1)
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))
@@ -639,15 +638,11 @@ def circuit_ansatz(params, wires):
     qml.QubitStateVector(unitary_group.rvs(2**4, random_state=0)[0], wires=wires)
     qml.RX(params[0], wires=wires[0])
     qml.RY(params[1], wires=wires[1])
-    qml.RX(params[2], wires=wires[2])
     qml.RZ(params[0], wires=wires[3])
     qml.CRX(params[3], wires=[wires[3], wires[0]])
     qml.PhaseShift(params[4], wires=wires[2])
     qml.CRY(params[5], wires=[wires[2], wires[1]])
-    qml.CRZ(params[5], wires=[wires[0], wires[3]])
-    qml.PhaseShift(params[6], wires=wires[0])
     qml.Rot(params[6], params[7], params[8], wires=wires[0])
-    qml.Rot(params[8], params[8], params[9], wires=wires[1])
     qml.MultiRZ(params[11], wires=[wires[0], wires[1]])
     # #     qml.PauliRot(params[12], "XXYZ", wires=[wires[0], wires[1], wires[2], wires[3]])
     qml.CPhase(params[12], wires=[wires[3], wires[2]])
@@ -655,7 +650,6 @@ def circuit_ansatz(params, wires):
     qml.IsingYY(params[14], wires=[wires[3], wires[2]])
     qml.IsingZZ(params[15], wires=[wires[2], wires[1]])
 
-    qml.CRot(params[21], params[22], params[23], wires=[wires[1], wires[2]])
     qml.SingleExcitation(params[24], wires=[wires[2], wires[0]])
     qml.DoubleExcitation(params[25], wires=[wires[2], wires[0], wires[1], wires[3]])
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,7 +298,7 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
-            qml.adjoint(qml.RY(0.5, wires=1),lazy=False)
+            qml.adjoint(qml.RY(0.5, wires=1), lazy=False)
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,6 +298,7 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
+            qml.adjoint(qml.RX(params[2], wires=wires[2]), lazy=False)
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))
@@ -638,18 +639,23 @@ def circuit_ansatz(params, wires):
     qml.QubitStateVector(unitary_group.rvs(2**4, random_state=0)[0], wires=wires)
     qml.RX(params[0], wires=wires[0])
     qml.RY(params[1], wires=wires[1])
+    qml.adjoint(qml.RX(params[2], wires=wires[2]))
     qml.RZ(params[0], wires=wires[3])
     qml.CRX(params[3], wires=[wires[3], wires[0]])
     qml.PhaseShift(params[4], wires=wires[2])
     qml.CRY(params[5], wires=[wires[2], wires[1]])
+    qml.adjoint(qml.CRZ(params[5], wires=[wires[0], wires[3]]))
+    qml.adjoint(qml.PhaseShift(params[6], wires=wires[0]))
     qml.Rot(params[6], params[7], params[8], wires=wires[0])
+    qml.adjoint(qml.Rot(params[8], params[8], params[9], wires=wires[1]))
     qml.MultiRZ(params[11], wires=[wires[0], wires[1]])
     # #     qml.PauliRot(params[12], "XXYZ", wires=[wires[0], wires[1], wires[2], wires[3]])
     qml.CPhase(params[12], wires=[wires[3], wires[2]])
     qml.IsingXX(params[13], wires=[wires[1], wires[0]])
     qml.IsingYY(params[14], wires=[wires[3], wires[2]])
     qml.IsingZZ(params[15], wires=[wires[2], wires[1]])
-
+    
+    qml.adjoint(qml.CRot(params[21], params[22], params[23], wires=[wires[1], wires[2]]))
     qml.SingleExcitation(params[24], wires=[wires[2], wires[0]])
     qml.DoubleExcitation(params[25], wires=[wires[2], wires[0], wires[1], wires[3]])
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -654,7 +654,7 @@ def circuit_ansatz(params, wires):
     qml.IsingXX(params[13], wires=[wires[1], wires[0]])
     qml.IsingYY(params[14], wires=[wires[3], wires[2]])
     qml.IsingZZ(params[15], wires=[wires[2], wires[1]])
-    
+
     qml.adjoint(qml.CRot(params[21], params[22], params[23], wires=[wires[1], wires[2]]))
     qml.SingleExcitation(params[24], wires=[wires[2], wires[0]])
     qml.DoubleExcitation(params[25], wires=[wires[2], wires[0], wires[1], wires[3]])

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,7 +298,7 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
-            qml.adjoint(qml.RY(0.5, wires=1), lazy=False)
+            qml.adjoint(qml.RY(0.5, wires=1))
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,7 +298,7 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
-            qml.RY(0.5, wires=1).inv()
+            qml.RY(0.5, wires=1)
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))
@@ -639,15 +639,15 @@ def circuit_ansatz(params, wires):
     qml.QubitStateVector(unitary_group.rvs(2**4, random_state=0)[0], wires=wires)
     qml.RX(params[0], wires=wires[0])
     qml.RY(params[1], wires=wires[1])
-    qml.RX(params[2], wires=wires[2]).inv()
+    qml.RX(params[2], wires=wires[2])
     qml.RZ(params[0], wires=wires[3])
     qml.CRX(params[3], wires=[wires[3], wires[0]])
     qml.PhaseShift(params[4], wires=wires[2])
     qml.CRY(params[5], wires=[wires[2], wires[1]])
-    qml.CRZ(params[5], wires=[wires[0], wires[3]]).inv()
-    qml.PhaseShift(params[6], wires=wires[0]).inv()
+    qml.CRZ(params[5], wires=[wires[0], wires[3]])
+    qml.PhaseShift(params[6], wires=wires[0])
     qml.Rot(params[6], params[7], params[8], wires=wires[0])
-    qml.Rot(params[8], params[8], params[9], wires=wires[1]).inv()
+    qml.Rot(params[8], params[8], params[9], wires=wires[1])
     qml.MultiRZ(params[11], wires=[wires[0], wires[1]])
     # #     qml.PauliRot(params[12], "XXYZ", wires=[wires[0], wires[1], wires[2], wires[3]])
     qml.CPhase(params[12], wires=[wires[3], wires[2]])
@@ -655,7 +655,7 @@ def circuit_ansatz(params, wires):
     qml.IsingYY(params[14], wires=[wires[3], wires[2]])
     qml.IsingZZ(params[15], wires=[wires[2], wires[1]])
 
-    qml.CRot(params[21], params[22], params[23], wires=[wires[1], wires[2]]).inv()
+    qml.CRot(params[21], params[22], params[23], wires=[wires[1], wires[2]])
     qml.SingleExcitation(params[24], wires=[wires[2], wires[0]])
     qml.DoubleExcitation(params[25], wires=[wires[2], wires[0], wires[1], wires[3]])
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -298,7 +298,7 @@ class TestAdjointJacobian:
 
             qml.Rot(1.3, -2.3, 0.5, wires=[0])
             qml.RZ(-0.5, wires=0)
-            qml.adjoint(qml.RY(0.5, wires=1))
+            qml.adjoint(qml.RY(0.5, wires=1),lazy=False)
             qml.CNOT(wires=[0, 1])
 
             qml.expval(obs(wires=0))

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -152,7 +152,7 @@ def test_inverse_unitary_correct(op, op_name):
         out = output(input)
         unitary[:, i] = out
 
-    unitary_expected = np.abs(qml.adjoint(op[0](*op[1], **op[2])))
+    unitary_expected = np.abs(qml.matrix(qml.adjoint(op[0](*op[1], **op[2]))))
 
     assert np.allclose(unitary, np.square(unitary_expected))
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -169,7 +169,7 @@ def test_inverse_unitary_correct(op, op_name):
     @qml.qnode(dev)
     def output(input):
         qml.BasisState(input, wires=range(wires))
-        op(*p, wires=range(wires)).inv()
+        op(*p, wires=range(wires))
         return qml.probs(range(wires))
 
     unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)
@@ -178,7 +178,7 @@ def test_inverse_unitary_correct(op, op_name):
         out = output(input)
         unitary[:, i] = out
 
-    unitary_expected = np.abs(qml.matrix(op(*p, wires=range(wires)).inv()))
+    unitary_expected = np.abs(qml.matrix(op(*p, wires=range(wires))))
 
     assert np.allclose(unitary, np.square(unitary_expected))
 
@@ -245,7 +245,7 @@ def test_arbitrary_inv_unitary_correct():
     @qml.qnode(dev)
     def output(input):
         qml.BasisState(input, wires=range(wires))
-        qml.QubitUnitary(random_unitary, wires=range(2)).inv()
+        qml.QubitUnitary(random_unitary, wires=range(2))
         return qml.probs(range(wires))
 
     unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -137,51 +137,52 @@ def test_gate_unitary_correct(op, op_name):
 
     assert np.allclose(unitary, np.square(unitary_expected))
 
-@pytest.mark.parametrize("op_name", LightningGPU.operations)	
+
+@pytest.mark.parametrize("op_name", LightningGPU.operations)
 def test_inverse_unitary_correct(op, op_name):
-    """Test if lightning.gpu correctly applies inverse gates by reconstructing the unitary matrix	
-    and comparing to the expected version"""	
+    """Test if lightning.gpu correctly applies inverse gates by reconstructing the unitary matrix
+    and comparing to the expected version"""
 
-    if op_name in ("BasisState", "QubitStateVector"):	
-        pytest.skip("Skipping operation because it is a state preparation")	
-    if op_name in (	
-        "ControlledQubitUnitary",	
-        "QubitUnitary",	
-        "MultiControlledX",	
-        "DiagonalQubitUnitary",	
-    ):	
-        pytest.skip("Skipping operation.")  # These are tested in the device test-suite	
-    if op == None:	
-        pytest.skip("Skipping operation.")	
+    if op_name in ("BasisState", "QubitStateVector"):
+        pytest.skip("Skipping operation because it is a state preparation")
+    if op_name in (
+        "ControlledQubitUnitary",
+        "QubitUnitary",
+        "MultiControlledX",
+        "DiagonalQubitUnitary",
+    ):
+        pytest.skip("Skipping operation.")  # These are tested in the device test-suite
+    if op == None:
+        pytest.skip("Skipping operation.")
 
-    wires = op.num_wires	
+    wires = op.num_wires
 
-    if wires == -1:  # This occurs for operations that do not have a predefined number of wires	
-        wires = 4	
+    if wires == -1:  # This occurs for operations that do not have a predefined number of wires
+        wires = 4
 
-    dev = qml.device("lightning.gpu", wires=wires)	
-    num_params = op.num_params	
-    p = [0.1] * num_params	
+    dev = qml.device("lightning.gpu", wires=wires)
+    num_params = op.num_params
+    p = [0.1] * num_params
 
-    op = getattr(qml, op_name)	
+    op = getattr(qml, op_name)
 
-    @qml.qnode(dev)	
-    def output(input):	
-        qml.BasisState(input, wires=range(wires))	
-        qml.adjoint(op(*p, wires=range(wires)))	
-        return qml.probs(range(wires))	
+    @qml.qnode(dev)
+    def output(input):
+        qml.BasisState(input, wires=range(wires))
+        qml.adjoint(op(*p, wires=range(wires)))
+        return qml.probs(range(wires))
 
-    unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)	
+    unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)
 
-    for i, input in enumerate(itertools.product([0, 1], repeat=wires)):	
-        out = output(input)	
-        unitary[:, i] = out	
+    for i, input in enumerate(itertools.product([0, 1], repeat=wires)):
+        out = output(input)
+        unitary[:, i] = out
 
-    unitary_expected = np.abs(qml.adjoint(qml.matrix(op(*p, wires=range(wires)))))	
+    unitary_expected = np.abs(qml.adjoint(qml.matrix(op(*p, wires=range(wires)))))
 
-    assert np.allclose(unitary, np.square(unitary_expected))	
+    assert np.allclose(unitary, np.square(unitary_expected))
 
-    
+
 random_unitary = np.array(
     [
         [
@@ -234,26 +235,27 @@ def test_arbitrary_unitary_correct():
 
     assert np.allclose(unitary, np.square(unitary_expected))
 
-def test_arbitrary_inv_unitary_correct():	
-    """Test if lightning.gpu correctly applies the inverse of an arbitrary unitary by	
-    reconstructing its matrix"""	
-    wires = 2	
-    dev = qml.device("lightning.gpu", wires=wires)	
 
-    @qml.qnode(dev)	
-    def output(input):	
-        qml.BasisState(input, wires=range(wires))	
+def test_arbitrary_inv_unitary_correct():
+    """Test if lightning.gpu correctly applies the inverse of an arbitrary unitary by
+    reconstructing its matrix"""
+    wires = 2
+    dev = qml.device("lightning.gpu", wires=wires)
+
+    @qml.qnode(dev)
+    def output(input):
+        qml.BasisState(input, wires=range(wires))
         qml.adjoint(qml.QubitUnitary(random_unitary, wires=range(2)))
-        return qml.probs(range(wires))	
+        return qml.probs(range(wires))
 
-    unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)	
+    unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)
 
-    for i, input in enumerate(itertools.product([0, 1], repeat=wires)):	
-        out = output(input)	
-        unitary[:, i] = out	
+    for i, input in enumerate(itertools.product([0, 1], repeat=wires)):
+        out = output(input)
+        unitary[:, i] = out
 
-    random_unitary_inv = random_unitary.conj().T	
+    random_unitary_inv = random_unitary.conj().T
 
-    unitary_expected = np.abs(random_unitary_inv)	
+    unitary_expected = np.abs(random_unitary_inv)
 
     assert np.allclose(unitary, np.square(unitary_expected))

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -177,7 +177,7 @@ def test_inverse_unitary_correct(op, op_name):
         out = output(input)	
         unitary[:, i] = out	
 
-    unitary_expected = np.abs(qml.matrix(op(*p, wires=range(wires)).inv()))	
+    unitary_expected = np.abs(qml.adjoint(qml.matrix(op(*p, wires=range(wires)))))	
 
     assert np.allclose(unitary, np.square(unitary_expected))	
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -138,50 +138,6 @@ def test_gate_unitary_correct(op, op_name):
     assert np.allclose(unitary, np.square(unitary_expected))
 
 
-@pytest.mark.parametrize("op_name", LightningGPU.operations)
-def test_inverse_unitary_correct(op, op_name):
-    """Test if lightning.gpu correctly applies inverse gates by reconstructing the unitary matrix
-    and comparing to the expected version"""
-
-    if op_name in ("BasisState", "QubitStateVector"):
-        pytest.skip("Skipping operation because it is a state preparation")
-    if op_name in (
-        "ControlledQubitUnitary",
-        "QubitUnitary",
-        "MultiControlledX",
-        "DiagonalQubitUnitary",
-    ):
-        pytest.skip("Skipping operation.")  # These are tested in the device test-suite
-    if op == None:
-        pytest.skip("Skipping operation.")
-
-    wires = op.num_wires
-
-    if wires == -1:  # This occurs for operations that do not have a predefined number of wires
-        wires = 4
-
-    dev = qml.device("lightning.gpu", wires=wires)
-    num_params = op.num_params
-    p = [0.1] * num_params
-
-    op = getattr(qml, op_name)
-
-    @qml.qnode(dev)
-    def output(input):
-        qml.BasisState(input, wires=range(wires))
-        op(*p, wires=range(wires))
-        return qml.probs(range(wires))
-
-    unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)
-
-    for i, input in enumerate(itertools.product([0, 1], repeat=wires)):
-        out = output(input)
-        unitary[:, i] = out
-
-    unitary_expected = np.abs(qml.matrix(op(*p, wires=range(wires))))
-
-    assert np.allclose(unitary, np.square(unitary_expected))
-
 
 random_unitary = np.array(
     [

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -37,58 +37,56 @@ except (ImportError, ModuleNotFoundError):
 @pytest.fixture
 def op(op_name):
     ops_list = {
-        "RX": qml.RX(0.123, wires=0),
-        "RY": qml.RY(1.434, wires=0),
-        "RZ": qml.RZ(2.774, wires=0),
-        "S": qml.S(wires=0),
-        "SX": qml.SX(wires=0),
-        "T": qml.T(wires=0),
-        "CNOT": qml.CNOT(wires=[0, 1]),
-        "CZ": qml.CZ(wires=[0, 1]),
-        "CY": qml.CY(wires=[0, 1]),
-        "SWAP": qml.SWAP(wires=[0, 1]),
-        "ISWAP": qml.ISWAP(wires=[0, 1]),
-        "SISWAP": qml.SISWAP(wires=[0, 1]),
-        "SQISW": qml.SQISW(wires=[0, 1]),
-        "CSWAP": qml.CSWAP(wires=[0, 1, 2]),
-        "PauliRot": qml.PauliRot(0.123, "Y", wires=0),
-        "IsingXX": qml.IsingXX(0.123, wires=[0, 1]),
-        "IsingYY": qml.IsingYY(0.123, wires=[0, 1]),
-        "IsingZZ": qml.IsingZZ(0.123, wires=[0, 1]),
-        "Identity": qml.Identity(wires=0),
-        "Rot": qml.Rot(0.123, 0.456, 0.789, wires=0),
-        "Toffoli": qml.Toffoli(wires=[0, 1, 2]),
-        "PhaseShift": qml.PhaseShift(2.133, wires=0),
-        "ControlledPhaseShift": qml.ControlledPhaseShift(1.777, wires=[0, 2]),
-        "CPhase": qml.CPhase(1.777, wires=[0, 2]),
-        "MultiRZ": qml.MultiRZ(0.123, wires=[0, 3]),
-        "MultiRZ": qml.MultiRZ(0.456, wires=[1, 2, 3]),
-        "MultiRZ": qml.MultiRZ(0.789, wires=[1, 2]),
-        "CRX": qml.CRX(0.836, wires=[2, 3]),
-        "CRY": qml.CRY(0.721, wires=[2, 3]),
-        "CRZ": qml.CRZ(0.554, wires=[2, 3]),
-        "Hadamard": qml.Hadamard(wires=0),
-        "PauliX": qml.PauliX(wires=0),
-        "PauliY": qml.PauliY(wires=0),
-        "PauliZ": qml.PauliZ(wires=0),
-        "CRot": qml.CRot(0.123, 0.456, 0.789, wires=[0, 1]),
-        "DiagonalQubitUnitary": qml.DiagonalQubitUnitary(np.array([1.0, 1.0j]), wires=1),
-        "ControlledQubitUnitary": qml.ControlledQubitUnitary(
-            np.eye(2) * 1j, wires=[0], control_wires=[2]
-        ),
-        "MultiControlledX": qml.MultiControlledX(
-            control_wires=[0, 1], wires=2, control_values="01"
-        ),
-        "SingleExcitation": qml.SingleExcitation(0.123, wires=[0, 3]),
-        "SingleExcitationPlus": qml.SingleExcitationPlus(0.123, wires=[0, 3]),
-        "SingleExcitationMinus": qml.SingleExcitationMinus(0.123, wires=[0, 3]),
-        "DoubleExcitation": qml.DoubleExcitation(0.123, wires=[0, 1, 2, 3]),
-        "DoubleExcitationPlus": qml.DoubleExcitationPlus(0.123, wires=[0, 1, 2, 3]),
-        "DoubleExcitationMinus": qml.DoubleExcitationMinus(0.123, wires=[0, 1, 2, 3]),
-        "QFT": qml.QFT(wires=0),
-        "QubitSum": qml.QubitSum(wires=[0, 1, 2]),
-        "QubitCarry": qml.QubitCarry(wires=[0, 1, 2, 3]),
-        "QubitUnitary": qml.QubitUnitary(np.eye(2) * 1j, wires=0),
+        "RX": [qml.RX, [], {"phi": 0.123, "wires": [0]}],
+        "RY": [qml.RY, [], {"phi": 1.434, "wires": [0]}],
+        "RZ": [qml.RZ, [], {"phi": 2.774, "wires": [0]}],
+        "S": [qml.S, [], {"wires": [0]}],
+        "SX": [qml.SX, [], {"wires": [0]}],
+        "T": [qml.T, [], {"wires": [0]}],
+        "CNOT": [qml.CNOT, [], {"wires": [0, 1]}],
+        "CZ": [qml.CZ, [], {"wires": [0, 1]}],
+        "CY": [qml.CY, [], {"wires": [0, 1]}],
+        "SWAP": [qml.SWAP, [], {"wires": [0, 1]}],
+        "ISWAP": [qml.ISWAP, [], {"wires": [0, 1]}],
+        "SISWAP": [qml.SISWAP, [], {"wires": [0, 1]}],
+        "SQISW": [qml.SQISW, [], {"wires": [0, 1]}],
+        "CSWAP": [qml.CSWAP, [], {"wires": [0, 1, 2]}],
+        "PauliRot": [qml.PauliRot, [0.123], {"pauli_word": "Y", "wires": [0]}],
+        "IsingXX": [qml.IsingXX, [], {"phi": 0.123, "wires": [0, 1]}],
+        "IsingXY": [qml.IsingXY, [], {"phi": 0.123, "wires": [0, 1]}],
+        "IsingYY": [qml.IsingYY, [], {"phi": 0.123, "wires": [0, 1]}],
+        "IsingZZ": [qml.IsingZZ, [], {"phi": 0.123, "wires": [0, 1]}],
+        "Identity": [qml.Identity, [], {"wires": [0]}],
+        "Rot": [qml.Rot, [], {"phi": 0.123, "theta": 0.456, "omega": 0.789, "wires": [0]}],
+        "Toffoli": [qml.Toffoli, [], {"wires": [0, 1, 2]}],
+        "PhaseShift": [qml.PhaseShift, [], {"phi": 2.133, "wires": [0]}],
+        "ControlledPhaseShift": [qml.ControlledPhaseShift, [], {"phi": 1.777, "wires": [0, 1]}],
+        "CPhase": [qml.CPhase, [], {"phi": 1.777, "wires": [0, 1]}],
+        "MultiRZ": [qml.MultiRZ, [], {"theta": 0.112, "wires": [0, 1, 2]}],
+        "CRX": [qml.CRX, [], {"phi": 0.123, "wires": [0, 1]}],
+        "CRY": [qml.CRY, [], {"phi": 0.123, "wires": [0, 1]}],
+        "CRZ": [qml.CRZ, [], {"phi": 0.123, "wires": [0, 1]}],
+        "Hadamard": [qml.Hadamard, [], {"wires": [0]}],
+        "PauliX": [qml.PauliX, [], {"wires": [0]}],
+        "PauliY": [qml.PauliY, [], {"wires": [0]}],
+        "PauliZ": [qml.PauliZ, [], {"wires": [0]}],
+        "CRot": [qml.CRot, [], {"phi": 0.123, "theta": 0.456, "omega": 0.789, "wires": [0, 1]}],
+        "DiagonalQubitUnitary": [qml.DiagonalQubitUnitary, [np.array([1.0, 1.0j])], {"wires": [0]}],
+        "MultiControlledX": [
+            qml.MultiControlledX,
+            [],
+            {"wires": [0, 1, 2], "control_values": "01"},
+        ],
+        "SingleExcitation": [qml.SingleExcitation, [0.123], {"wires": [0, 1]}],
+        "SingleExcitationPlus": [qml.SingleExcitationPlus, [0.123], {"wires": [0, 1]}],
+        "SingleExcitationMinus": [qml.SingleExcitationMinus, [0.123], {"wires": [0, 1]}],
+        "DoubleExcitation": [qml.DoubleExcitation, [0.123], {"wires": [0, 1, 2, 3]}],
+        "DoubleExcitationPlus": [qml.DoubleExcitationPlus, [0.123], {"wires": [0, 1, 2, 3]}],
+        "DoubleExcitationMinus": [qml.DoubleExcitationMinus, [0.123], {"wires": [0, 1, 2, 3]}],
+        "QFT": [qml.QFT, [], {"wires": [0]}],
+        "QubitSum": [qml.QubitSum, [], {"wires": [0, 1, 2]}],
+        "QubitCarry": [qml.QubitCarry, [], {"wires": [0, 1, 2, 3]}],
+        "QubitUnitary": [qml.QubitUnitary, [], {"U": np.eye(16) * 1j, "wires": [0, 1, 2, 3]}],
     }
     return ops_list.get(op_name)
 
@@ -100,31 +98,21 @@ def test_gate_unitary_correct(op, op_name):
 
     if op_name in ("BasisState", "QubitStateVector"):
         pytest.skip("Skipping operation because it is a state preparation")
-    if op_name in (
-        "ControlledQubitUnitary",
-        "QubitUnitary",
-        "MultiControlledX",
-        "DiagonalQubitUnitary",
-    ):
-        pytest.skip(f"Skipping operation {op_name}.")  # These are tested in the device test-suite
+
     if op == None:
         pytest.skip("Skipping operation.")
 
-    wires = op.num_wires
+    wires = len(op[2]["wires"])
 
     if wires == -1:  # This occurs for operations that do not have a predefined number of wires
         wires = 4
 
     dev = qml.device("lightning.gpu", wires=wires)
-    num_params = op.num_params
-    p = [0.1] * num_params
-
-    op = getattr(qml, op_name)
 
     @qml.qnode(dev)
     def output(input):
         qml.BasisState(input, wires=range(wires))
-        op(*p, wires=range(wires))
+        op[0](*op[1], **op[2])
         return qml.probs(range(wires))
 
     unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)
@@ -133,7 +121,7 @@ def test_gate_unitary_correct(op, op_name):
         out = output(input)
         unitary[:, i] = out
 
-    unitary_expected = np.abs(qml.matrix(op(*p, wires=range(wires))))
+    unitary_expected = np.abs(qml.matrix(op[0](*op[1], **op[2])))
 
     assert np.allclose(unitary, np.square(unitary_expected))
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -234,28 +234,3 @@ def test_arbitrary_unitary_correct():
     unitary_expected = np.abs(random_unitary)
 
     assert np.allclose(unitary, np.square(unitary_expected))
-
-
-def test_arbitrary_inv_unitary_correct():
-    """Test if lightning.gpu correctly applies the inverse of an arbitrary unitary by
-    reconstructing its matrix"""
-    wires = 2
-    dev = qml.device("lightning.gpu", wires=wires)
-
-    @qml.qnode(dev)
-    def output(input):
-        qml.BasisState(input, wires=range(wires))
-        qml.QubitUnitary(random_unitary, wires=range(2))
-        return qml.probs(range(wires))
-
-    unitary = np.zeros((2**wires, 2**wires), dtype=np.float64)
-
-    for i, input in enumerate(itertools.product([0, 1], repeat=wires)):
-        out = output(input)
-        unitary[:, i] = out
-
-    random_unitary_inv = random_unitary.conj().T
-
-    unitary_expected = np.abs(random_unitary_inv)
-
-    assert np.allclose(unitary, np.square(unitary_expected))

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -138,7 +138,6 @@ def test_gate_unitary_correct(op, op_name):
     assert np.allclose(unitary, np.square(unitary_expected))
 
 
-
 random_unitary = np.array(
     [
         [


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

`inv()` methods are removed from Python unit tests based on recent changes in [Pennylane](https://github.com/PennyLaneAI/pennylane/pull/3618) recently.

**Description of the Change:**

`inv()` methods are changed to `qml.adjoint()` methods Python unit tests.

**Benefits:**

This will avoid the CI failures caused by removing `inv()` methods from Pennylane.

**Possible Drawbacks:**

**Related GitHub Issues:**
