### PR TITLE
Downgrade Numpy to avoid conflicts

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* Limit Numpy version to avoid conflicts with Autograd.
+[(#89)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/89)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Amintor Dusko
 
 ---
 

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev0"
+__version__ = "0.29.0-dev1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ninja
 cmake
 cuquantum>=22.3.0
 flaky
-numpy
+numpy<1.24
 pennylane>=0.22
 pennylane-lightning>=0.22
 pybind11

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ requirements = [
     "ninja",
     "wheel",
     "cmake",
-    "numpy",
+    "numpy<1.24",
     "pennylane-lightning>=0.22",
     "pennylane>=0.22",
 ]

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -490,7 +490,6 @@ class TestApply:
             DeviceError,
             match="Operation QubitStateVector cannot be used after other Operations have already been applied ",
         ):
-
             qubit_device_2_wires.reset()
             qubit_device_2_wires.apply(
                 [

--- a/tests/test_hamiltonian.py
+++ b/tests/test_hamiltonian.py
@@ -63,7 +63,6 @@ class TestHamiltonianExpval:
         assert np.allclose(circuit(), res, atol=tol, rtol=0)
 
     def test_hamiltonan_expectation(self, qubit_device_3_wires, tol):
-
         dev = qubit_device_3_wires
 
         obs = qml.PauliX(1) @ qml.PauliY(2)

--- a/tests/test_hamiltonian_sparse.py
+++ b/tests/test_hamiltonian_sparse.py
@@ -35,7 +35,6 @@ except (ImportError, ModuleNotFoundError):
 
 class TestHamiltonianExpval:
     def test_hamiltonian_expectation(self, qubit_device_3_wires, tol):
-
         dev = qubit_device_3_wires
         obs = qml.Identity(0) @ qml.PauliX(1) @ qml.PauliY(2)
 


### PR DESCRIPTION
**Context:** Numpy last minor version 1.24 has some conflicts with Autograd.

**Description of the Change:** For now we'll limit installation to Numpy < 1.24

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
