### PR TITLE
Remove explicit Numpy requirement

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Update `inv()` to `qml.adjoint()` in Python tests following recent changes in Pennylane.
  [(#88)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/88)
 
-* Remove explicit Numpy dependence.
+* Remove explicit Numpy requirement.
 [(#90)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/90)
 
 ### Documentation

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 * Update `inv()` to `qml.adjoint()` in Python tests following recent changes in Pennylane.
  [(#88)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/88)
- 
+
+* Remove explicit Numpy dependence.
+[(#90)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/90)
+
 ### Documentation
 
 ### Bug fixes
-
-* Limit Numpy version to avoid conflicts with Autograd.
-[(#89)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/89)
 
 ### Contributors
 

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev1"
+__version__ = "0.29.0-dev2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@ ninja
 cmake
 cuquantum>=22.3.0
 flaky
-numpy<1.24
-pennylane>=0.22
-pennylane-lightning>=0.22
+pennylane>=0.28
+pennylane-lightning>=0.28
 pybind11
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -96,9 +96,8 @@ requirements = [
     "ninja",
     "wheel",
     "cmake",
-    "numpy<1.24",
-    "pennylane-lightning>=0.22",
-    "pennylane>=0.22",
+    "pennylane-lightning>=0.28",
+    "pennylane>=0.28",
 ]
 
 info = {


### PR DESCRIPTION
**Context:** PennyLane is a hard dependence and already provides Numpy as a requirement.

**Description of the Change:** Remove explicit Numpy and Scipy dependence

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
