### PR TITLE
Update to new return types specification

### DIFF
--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -124,7 +124,7 @@ jobs:
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           # Sync with latest master branches
           python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
-          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
           
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -687,9 +687,7 @@ if CPP_BINARY_AVAILABLE:
                     new_tape = tape.copy()
                     new_tape._measurements = [qml.expval(ham)]
 
-                    return self.adjoint_jacobian(
-                        new_tape, starting_state, use_device_state
-                    )
+                    return self.adjoint_jacobian(new_tape, starting_state, use_device_state)
 
                 return processing_fn
 

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -572,9 +572,8 @@ if CPP_BINARY_AVAILABLE:
             all_params = 0
 
             for op_idx, tp in enumerate(trainable_params):
-                op, _ = tape.get_operation(
-                    op_idx
-                )  # get op_idx-th operator among differentiable operators
+                # get op_idx-th operator among differentiable operators
+                op, _, _ = tape.get_operation(op_idx, return_op_index=True)
 
                 if isinstance(op, Operation) and not isinstance(op, (BasisState, QubitStateVector)):
                     # We now just ignore non-op or state preps
@@ -632,7 +631,24 @@ if CPP_BINARY_AVAILABLE:
                 else:
                     jac_r[idx, :] = jac[obs_offsets[idx] : obs_offsets[idx + 1], :]
 
-            return jac_r
+            return self._adjoint_jacobian_processing(jac_r) if qml.active_return() else jac_r
+
+        @staticmethod
+        def _adjoint_jacobian_processing(jac):
+            """
+            Post-process the Jacobian matrix returned by ``adjoint_jacobian`` for
+            the new return type system.
+            """
+            jac = np.squeeze(jac)
+
+            if jac.ndim == 0:
+                return np.array(jac)
+
+            if jac.ndim == 1:
+                return tuple(np.array(j) for j in jac)
+
+            # must be 2-dimensional
+            return tuple(tuple(np.array(j_) for j_ in j) for j in jac)
 
         def vjp(self, measurements, dy, starting_state=None, use_device_state=False):
             """Generate the processing function required to compute the vector-Jacobian products of a tape."""
@@ -673,7 +689,7 @@ if CPP_BINARY_AVAILABLE:
 
                     return self.adjoint_jacobian(
                         new_tape, starting_state, use_device_state
-                    ).reshape(-1)
+                    )
 
                 return processing_fn
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -819,10 +819,10 @@ def test_integration_custom_wires_batching(returns):
     qnode_lightning = qml.QNode(circuit, dev_lightning, diff_method="adjoint")
 
     def convert_to_array_gpu(params):
-        return np.array(qnode_gpu(params))
+        return np.hstack(qnode_gpu(params))
 
     def convert_to_array_lightning(params):
-        return np.array(qnode_lightning(params))
+        return np.hstack(qnode_lightning(params))
 
     j_gpu = qml.jacobian(convert_to_array_gpu)(params)
     j_lightning = qml.jacobian(convert_to_array_lightning)(params)
@@ -871,7 +871,7 @@ def test_batching_H(returns):
 
     def circuit(params):
         circuit_ansatz(params, wires=custom_wires)
-        return [qml.expval(r) for r in returns]
+        return np.array([qml.expval(r) for r in returns])
 
     n_params = 30
     np.random.seed(1337)
@@ -882,13 +882,13 @@ def test_batching_H(returns):
     qnode_gpu_default = qml.QNode(circuit, dev_gpu_default, diff_method="adjoint")
 
     def convert_to_array_cpu(params):
-        return np.array(qnode_cpu(params))
+        return np.hstack(qnode_cpu(params))
 
     def convert_to_array_gpu(params):
-        return np.array(qnode_gpu(params))
+        return np.hstack(qnode_gpu(params))
 
     def convert_to_array_gpu_default(params):
-        return np.array(qnode_gpu_default(params))
+        return np.hstack(qnode_gpu_default(params))
 
     j_cpu = qml.jacobian(qnode_cpu)(params)
     j_gpu = qml.jacobian(qnode_gpu)(params)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -890,7 +890,6 @@ def test_batching_H(returns):
     def convert_to_array_gpu_default(params):
         return np.array(qnode_gpu_default(params))
 
-
     j_cpu = qml.jacobian(qnode_cpu)(params)
     j_gpu = qml.jacobian(qnode_gpu)(params)
     j_gpu_default = qml.jacobian(qnode_gpu_default)(params)

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -16,7 +16,7 @@ Tests for the ``vjp`` method of`pennylane_lightning_gpu.LightningGPU`.
 """
 import pytest
 
-import numpy as np
+from pennylane import numpy as np
 import pennylane as qml
 from pennylane_lightning_gpu import LightningGPU
 
@@ -69,4 +69,4 @@ class TestVectorJacobianProduct:
 
         vjp2 = dev.adjoint_jacobian(tape2, use_device_state=True)
 
-        assert np.allclose(vjp1, vjp2.ravel(order="C"), atol=tol, rtol=0)
+        assert np.allclose(vjp1, vjp2, atol=tol, rtol=0)


### PR DESCRIPTION
See also Lightning PR #427 : https://github.com/PennyLaneAI/pennylane-lightning/pull/427/files?diff=unified&w=0

Context:

With Pennylane PR #3957: https://github.com/PennyLaneAI/pennylane/pull/3957 , the new return types system is enabled by default.

To make sure lightning-gpu works with pennylane master, we need to change the return shape from adjoint_jacobian. The return shape from execute in handled inside QubitDevice.

Description of the Change:

The changes to the source code are:

Change the output of adjoint_jacobian to match the new nested tuples specification
Change use of tape.get_parameters to eliminate deprecation warning


The changes to the tests are:

change expected shape in a couple places
switch finite_diff to param_shift, as finite diff was causing errors with float32
Cast output to a numpy array from a tuple when using autograd, as autograd cannot differentiate a tuple
Benefits:
It works with PennyLane master.

Possible Drawbacks:
None

Related GitHub Issues:
None