### PR TITLE
custatevec-cu11 fixes cuquantum version?

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Bug fixes
 
+* Fix CUDA version to 11 for cuquantum dependency in CI. 
+[(#107)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/107)
+
 * Fix the controlled-gate generators, which are now fully used in the adjoint pipeline following PennyLane PR [(#3874)](https://github.com/PennyLaneAI/pennylane/pull/3874).
 [(#101)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/101)
 
@@ -21,7 +24,7 @@
 
 ### Contributors
 
-Romain Moyard, Lee James O'Riordan
+Vincent Michaud-Rioux, Romain Moyard, Lee James O'Riordan
 
 ---
 

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
-          python -m pip install ninja cmake~=3.24.3 cuquantum
-
+          python -m pip install ninja cmake~=3.24.3 custatevec-cu11 cuquantum 
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3
 
@@ -146,7 +145,7 @@ jobs:
         run: |
           source ${{ steps.setup_venv.outputs.venv_name }}/bin/activate
           python3 -m pip install pip~=22.0
-          python3 -m pip install ninja cmake cuquantum pytest pytest-mock flaky pytest-cov
+          python3 -m pip install ninja cmake custatevec-cu11 cuquantum pytest pytest-mock flaky pytest-cov
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           # Sync with latest master branches
           python3 -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
-          python -m pip install ninja cmake~=3.24.3 cuquantum-cu11 
+          python -m pip install ninja cmake~=3.24.3 custatevec-cu11 
           
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3
@@ -147,7 +147,7 @@ jobs:
         run: |
           source ${{ steps.setup_venv.outputs.venv_name }}/bin/activate
           python3 -m pip install pip~=22.0
-          python3 -m pip install ninja cmake cuquantum-cu11 pytest pytest-mock flaky pytest-cov
+          python3 -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           # Sync with latest master branches
           python3 -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
-          python -m pip install ninja cmake~=3.24.3 custatevec-cu11 cuquantum 
+          python -m pip install ninja cmake~=3.24.3 custatevec-cu11 
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3
 

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -127,6 +127,7 @@ jobs:
         id: setup_venv
         env:
           VENV_NAME: venv_${{ steps.setup_python.outputs.python-version }}_${{ github.sha }}
+
         run: |
           # Clear any pre-existing venvs
           rm -rf venv_*
@@ -153,6 +154,8 @@ jobs:
           python3 -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
           
       - name: Build and install package
+        env: 
+          CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")
         run: |
           source ${{ steps.setup_venv.outputs.venv_name }}/bin/activate
           python3 setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});LIGHTNING_RELEASE_TAG=master;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }}"

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
-          python -m pip install ninja cmake~=3.24.3 custatevec-cu11 
+          python -m pip install ninja cmake~=3.24.3 cuquantum-cu11 
+          
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3
 
@@ -145,7 +146,7 @@ jobs:
         run: |
           source ${{ steps.setup_venv.outputs.venv_name }}/bin/activate
           python3 -m pip install pip~=22.0
-          python3 -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov
+          python3 -m pip install ninja cmake cuquantum-cu11 pytest pytest-mock flaky pytest-cov
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           # Sync with latest master branches
           python3 -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           source ${{ steps.setup_venv.outputs.venv_name }}/bin/activate
           python3 -m pip install pip~=22.0
-          python3 -m pip install ninja cmake custatevec-cu11 cuquantum pytest pytest-mock flaky pytest-cov
+          python3 -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           # Sync with latest master branches
           python3 -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master


### PR DESCRIPTION
**Context:**
L-GPU compiled libraries are still jumping to favour CUDA 12 over CUDA 11. We may need to favour building using custatevec-cu11 rather than the generic cuquantum package, which seems to also pull in 12.

**Description of the Change:**
Swap cuquantum PyPi package for custatevec-cu11 and add `CUQUANTUM_SDK` env var.

**Benefits:**
Fixes build issues.
Smaller dependency.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
