### PR TITLE
Update tests for PL 0.31 to remove deprecated functions

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* Update tests to be compliant with PennyLane v0.31.0 development changes and deprecations.
+  [(#114)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/114)
+
 ### Improvements
 
 ### Documentation
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Shuli Shu
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ doc/__pycache__/
 # build system
 build/
 dist/
+BuildTests/
 
 # misc
 .idea

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,7 @@ sphinx:
 
 python:
   install:
+    - requirements: ci_build_requirements.txt
     - requirements: doc/requirements.txt
     - requirements: requirements.txt
     - method: pip
@@ -17,4 +18,10 @@ build:
     python: "3.8"
   apt_packages:
     - cmake
+    - build-essential
+    - libopenblas-base
+    - libopenblas-dev
     - graphviz
+  jobs:
+    pre_install:
+      - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/pennylane_lightning_gpu/_version.py
+++ b/pennylane_lightning_gpu/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.31.0-dev0"
+__version__ = "0.31.0-dev1"

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -655,6 +655,7 @@ def test_qchem_expvalcost_correct():
     hf_state = qchem.hf_state(active_electrons, qubits)
 
     dev_lig = qml.device("lightning.gpu", wires=qubits)
+
     @qml.qnode(dev_lig, diff_method="adjoint")
     def circuit_1(params, wires):
         qml.BasisState(hf_state, wires=wires)
@@ -668,6 +669,7 @@ def test_qchem_expvalcost_correct():
     grads_lig = qml.grad(circuit_1)(params, wires=range(qubits))
 
     dev_def = qml.device("default.qubit", wires=qubits)
+
     @qml.qnode(dev_def, diff_method="backprop")
     def circuit_2(params, wires):
         qml.BasisState(hf_state, wires=wires)
@@ -676,6 +678,7 @@ def test_qchem_expvalcost_correct():
         qml.RZ(params[0], wires=2)
         qml.Hadamard(wires=1)
         return qml.expval(H)
+
     params = np.array([0.123], requires_grad=True)
     grads_def = qml.grad(circuit_2)(params, wires=range(qubits))
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -1073,23 +1073,23 @@ def test_fail_adjoint_mixed_Hamiltonian_Hermitian(returns):
     "returns",
     [
         qml.SparseHamiltonian(
-            #qml.utils.sparse_hamiltonian(
+            # qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
-                0.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])
+                [0.1], qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])
             ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
-            #qml.utils.sparse_hamiltonian(
+            # qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
-                2 * qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])
+                [2.0], qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])
             ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
-            #qml.utils.sparse_hamiltonian(
+            # qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
-                1.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])
+                [1.1], qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])
             ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -1007,24 +1007,24 @@ def test_fail_adjoint_mixed_Hamiltonian_Hermitian(returns):
     "returns",
     [
         qml.SparseHamiltonian(
-            qml.utils.sparse_hamiltonian(
-                0.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1]),
-                wires=custom_wires,
-            ),
+            #qml.utils.sparse_hamiltonian(
+            qml.Hamiltonian(
+                0.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])
+            ).sparse_matrix(),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
-            qml.utils.sparse_hamiltonian(
-                2 * qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0]),
-                wires=custom_wires,
-            ),
+            #qml.utils.sparse_hamiltonian(
+            qml.Hamiltonian(
+                2 * qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])
+            ).sparse_matrix(),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
-            qml.utils.sparse_hamiltonian(
-                1.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2]),
-                wires=custom_wires,
-            ),
+            #qml.utils.sparse_hamiltonian(
+            qml.Hamiltonian(
+                1.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])
+            ).sparse_matrix(),
             wires=custom_wires,
         ),
     ],

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -1073,23 +1073,20 @@ def test_fail_adjoint_mixed_Hamiltonian_Hermitian(returns):
     "returns",
     [
         qml.SparseHamiltonian(
-            # qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
-                [0.1], qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])
+                [0.1], [qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])]
             ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
-            # qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
-                [2.0], qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])
+                [2.0], [qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])]
             ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
-            # qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
-                [1.1], qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])
+                [1.1], [qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])]
             ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -654,25 +654,30 @@ def test_qchem_expvalcost_correct():
     active_electrons = 2
     hf_state = qchem.hf_state(active_electrons, qubits)
 
+    dev_lig = qml.device("lightning.gpu", wires=qubits)
+    @qml.qnode(dev_lig, diff_method="adjoint")
     def circuit_1(params, wires):
         qml.BasisState(hf_state, wires=wires)
         qml.RX(params[0], wires=0)
         qml.RY(params[0], wires=1)
         qml.RZ(params[0], wires=2)
         qml.Hadamard(wires=1)
+        return qml.expval(H)
 
-    diff_method = "adjoint"
-    dev_lig = qml.device("lightning.gpu", wires=qubits)
-    cost_fn_lig = qml.ExpvalCost(circuit_1, H, dev_lig, optimize=False, diff_method=diff_method)
-    circuit_gradient_lig = qml.grad(cost_fn_lig, argnum=0)
     params = np.array([0.123], requires_grad=True)
-    grads_lig = circuit_gradient_lig(params)
+    grads_lig = qml.grad(circuit_1)(params, wires=range(qubits))
 
     dev_def = qml.device("default.qubit", wires=qubits)
-    cost_fn_def = qml.ExpvalCost(circuit_1, H, dev_def, optimize=False, diff_method=diff_method)
-    circuit_gradient_def = qml.grad(cost_fn_def, argnum=0)
+    @qml.qnode(dev_def, diff_method="backprop")
+    def circuit_2(params, wires):
+        qml.BasisState(hf_state, wires=wires)
+        qml.RX(params[0], wires=0)
+        qml.RY(params[0], wires=1)
+        qml.RZ(params[0], wires=2)
+        qml.Hadamard(wires=1)
+        return qml.expval(H)
     params = np.array([0.123], requires_grad=True)
-    grads_def = circuit_gradient_def(params)
+    grads_def = qml.grad(circuit_2)(params, wires=range(qubits))
 
     assert np.allclose(grads_lig, grads_def)
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -1010,21 +1010,21 @@ def test_fail_adjoint_mixed_Hamiltonian_Hermitian(returns):
             #qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
                 0.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[1])
-            ).sparse_matrix(),
+            ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
             #qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
                 2 * qml.PauliX(wires=custom_wires[2]) @ qml.PauliZ(wires=custom_wires[0])
-            ).sparse_matrix(),
+            ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
         qml.SparseHamiltonian(
             #qml.utils.sparse_hamiltonian(
             qml.Hamiltonian(
                 1.1 * qml.PauliX(wires=custom_wires[0]) @ qml.PauliZ(wires=custom_wires[2])
-            ).sparse_matrix(),
+            ).sparse_matrix(custom_wires),
             wires=custom_wires,
         ),
     ],

--- a/tests/test_hamiltonian_sparse.py
+++ b/tests/test_hamiltonian_sparse.py
@@ -57,7 +57,6 @@ class TestHamiltonianExpval:
         )
 
         dev.syncH2D(state_vector)
-        # Hmat = qml.utils.sparse_hamiltonian(H)
         H_sparse = qml.SparseHamiltonian(Hmat, wires=range(3))
 
         res = dev.expval(H_sparse)
@@ -72,7 +71,6 @@ class TestSparseExpval:
     @pytest.fixture(params=[np.complex64, np.complex128])
     def dev(self, request):
         return LightningGPU(wires=2, c_dtype=request.param)
-        # return qml.device("lightning.qubit", wires=2, c_dtype=request.param)
 
     @pytest.mark.parametrize(
         "cases",

--- a/tests/test_hamiltonian_sparse.py
+++ b/tests/test_hamiltonian_sparse.py
@@ -57,7 +57,7 @@ class TestHamiltonianExpval:
         )
 
         dev.syncH2D(state_vector)
-        #Hmat = qml.utils.sparse_hamiltonian(H)
+        # Hmat = qml.utils.sparse_hamiltonian(H)
         H_sparse = qml.SparseHamiltonian(Hmat, wires=range(3))
 
         res = dev.expval(H_sparse)

--- a/tests/test_hamiltonian_sparse.py
+++ b/tests/test_hamiltonian_sparse.py
@@ -40,7 +40,7 @@ class TestHamiltonianExpval:
 
         obs1 = qml.Identity(1)
 
-        H = qml.Hamiltonian([1.0, 1.0], [obs1, obs])
+        Hmat = qml.Hamiltonian([1.0, 1.0], [obs1, obs]).sparse_matrix()
 
         state_vector = np.array(
             [
@@ -57,7 +57,7 @@ class TestHamiltonianExpval:
         )
 
         dev.syncH2D(state_vector)
-        Hmat = qml.utils.sparse_hamiltonian(H)
+        #Hmat = qml.utils.sparse_hamiltonian(H)
         H_sparse = qml.SparseHamiltonian(Hmat, wires=range(3))
 
         res = dev.expval(H_sparse)
@@ -94,7 +94,7 @@ class TestSparseExpval:
             qml.RY(-0.2, wires=[1])
             return qml.expval(
                 qml.SparseHamiltonian(
-                    qml.utils.sparse_hamiltonian(qml.Hamiltonian([1], [cases[0]])), wires=[0, 1]
+                    qml.Hamiltonian([1], [cases[0]]).sparse_matrix(), wires=[0, 1]
                 )
             )
 
@@ -125,7 +125,7 @@ class TestSparseExpval:
             qml.RY(-0.2, wires=[1])
             return qml.expval(
                 qml.SparseHamiltonian(
-                    qml.utils.sparse_hamiltonian(qml.Hamiltonian([1], [cases[0]])), wires=[0, 1]
+                    qml.Hamiltonian([1], [cases[0]]).sparse_matrix(), wires=[0, 1]
                 )
             )
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

 PennyLane v0.30.0-dev has removed support for previously deprecated functions, as defined in https://docs.pennylane.ai/en/stable/development/deprecations.html. This PR updates those functions to the new supported syntax.

**Description of the Change:**

As above. In addition, due to an ongoing issue with RTD builds using unaligned versions of setuptools and pip, we create a subtle change to the RTD builder to fix the package versions until https://github.com/readthedocs/readthedocs.org/pull/10287 becomes usable. In addition, to avoid CI issues, CYBot is now GHBot and will auto-update the package versions in the CI.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
