### PR TITLE
Use `Operator.name` instead of `Operation.base_name`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Improvements
 
 * Use `Operator.name` instead of `Operation.base_name`.
+  [(#115)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/115)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Improvements
 
+* Use `Operator.name` instead of `Operation.base_name`.
+
 ### Documentation
 
 ### Bug fixes
@@ -17,7 +19,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Shuli Shu
+Christina Lee, Shuli Shu
 
 ---
 

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -417,7 +417,7 @@ if CPP_BINARY_AVAILABLE:
             invert_param = False
 
             for o in operations:
-                if o.name in skipped_ops:
+                if str(o.name) in skipped_ops:
                     continue
                 name = o.name
                 if isinstance(o, Adjoint):

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -417,7 +417,7 @@ if CPP_BINARY_AVAILABLE:
             invert_param = False
 
             for o in operations:
-                if o.base_name in skipped_ops:
+                if o.name in skipped_ops:
                     continue
                 name = o.name
                 if isinstance(o, Adjoint):


### PR DESCRIPTION
**Context:**

`Operation.base_name` is a holdover from when in-place inversion modified the name of the object. Since in-place inversion is removed, there is no reason to keep `base_name` around any longer. `name` does exactly the same thing.

**Description of the Change:**

Use `Operator.name` instead of `Operation.base_name`

**Benefits:**

PennyLane can deprecate `Operation.base_name`.

**Possible Drawbacks:**

None

**Related GitHub Issues:**
