### PR TITLE
Updated runs-on label for self-hosted runner workflows

### DIFF
--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -20,6 +20,8 @@ jobs:
   cpptests:
     runs-on:
       - self-hosted
+      - linux
+      - x64
       - ubuntu-22.04
       - gpu
 
@@ -132,11 +134,14 @@ jobs:
           rm -rf .git
           rm -rf .gitignore
           rm -rf .github
+          pip cache purge
 
 
   pythontests:
     runs-on:
       - self-hosted
+      - linux
+      - x64
       - ubuntu-22.04
       - gpu
 
@@ -221,3 +226,4 @@ jobs:
           rm -rf .git
           rm -rf .gitignore
           rm -rf .github
+          pip cache purge


### PR DESCRIPTION
**Context:**
Since there is only one set runners for this repo currently the infra is setup such that if any of the labels on a requesting workflow matches that that is setup on the AWS hosted runner, the webhook is accepted and a runner is deployed.

However, now with multi-gpu runners coming into the picture, it is important to only deploy the exact type of runner we want. To accommodate for this, the infrastructure will be updated such that all labels attached to a runner must be present by the requesting workflow, this ensures that a single gpu runner is not accidentally deployed for a multi-gpu job, or vice versa.

If a job does not contain all the labels needed to deploy a runner, the request will simply get dropped on the AWS side.

**Description of the Change:**
Adds all the labels that are tied to single-gpu runners, ensuring the workflow do not break once the new change is in.

The current AWS runner labels are:
```
["self-hosted","linux","x64","ubuntu-22.04","gpu"]
```

**Benefits:**
Avoid ambiguity with multi-gpu runner.

**Possible Drawbacks:**
Job never getting picked up by a runner if the labels are not setup properly.

**Related GitHub Issues:**
None.