### PR TITLE
[sc-40238]: Add compat workflows

### DIFF
--- a/.github/workflows/compat-check-latest-latest.yml
+++ b/.github/workflows/compat-check-latest-latest.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - latest/latest
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-latest-latest.yml
+++ b/.github/workflows/compat-check-latest-latest.yml
@@ -1,6 +1,7 @@
 name: Compat Check w/PL - latest/latest
 
 on:
+  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-latest-latest.yml
+++ b/.github/workflows/compat-check-latest-latest.yml
@@ -1,0 +1,22 @@
+name: Compat Check w/PL - latest/latest
+
+on:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux_x86:
+    name: Lightning-GPU Compatibility test (tests_linux_x86) - latest/latest
+    uses: ./.github/workflows/tests_linux_x86.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: latest
+
+  tests_linux_x86_mpich:
+    name: Lightning-GPU Compatibility test (tests_linux_x86_mpich) - latest/latest
+    uses: ./.github/workflows/tests_linux_x86_mpich.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: latest
+

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - latest/stable
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -1,6 +1,7 @@
 name: Compat Check w/PL - latest/stable
 
 on:
+  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -1,0 +1,22 @@
+name: Compat Check w/PL - latest/stable
+
+on:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux_x86:
+    name: Lightning-GPU Compatibility test (tests_linux_x86) - latest/stable
+    uses: ./.github/workflows/tests_linux_x86.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: stable
+
+  tests_linux_x86_mpich:
+    name: Lightning-GPU Compatibility test (tests_linux_x86_mpich) - latest/stable
+    uses: ./.github/workflows/tests_linux_x86_mpich.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: stable
+

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - stable/latest
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -1,6 +1,7 @@
 name: Compat Check w/PL - stable/latest
 
 on:
+  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -1,0 +1,22 @@
+name: Compat Check w/PL - stable/latest
+
+on:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux_x86:
+    name: Lightning-GPU Compatibility test (tests_linux_x86) - stable/latest
+    uses: ./.github/workflows/tests_linux_x86.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: latest
+
+  tests_linux_x86_mpich:
+    name: Lightning-GPU Compatibility test (tests_linux_x86_mpich) - stable/latest
+    uses: ./.github/workflows/tests_linux_x86_mpich.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: latest
+

--- a/.github/workflows/compat-check-stable-stable.yml
+++ b/.github/workflows/compat-check-stable-stable.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - stable/stable
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-stable.yml
+++ b/.github/workflows/compat-check-stable-stable.yml
@@ -1,6 +1,7 @@
 name: Compat Check w/PL - stable/stable
 
 on:
+  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-stable.yml
+++ b/.github/workflows/compat-check-stable-stable.yml
@@ -1,0 +1,22 @@
+name: Compat Check w/PL - stable/stable
+
+on:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux_x86:
+    name: Lightning-GPU Compatibility test (tests_linux_x86) - stable/stable
+    uses: ./.github/workflows/tests_linux_x86.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: stable
+
+  tests_linux_x86_mpich:
+    name: Lightning-GPU Compatibility test (tests_linux_x86_mpich) - stable/stable
+    uses: ./.github/workflows/tests_linux_x86_mpich.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: stable
+

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -249,16 +249,16 @@ jobs:
           echo "PIP Path => $pip_path"
           echo "pip=$pip_path" >> $GITHUB_OUTPUT
 
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Install required packages
         run: |
           python -m pip install pip~=22.0
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov
           # Sync with latest master branches
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
-
-      - name: Install Latest PennyLane
-        if: ${{ inputs.pennylane-version == 'latest' }}
-        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and install package
         env: 

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -1,5 +1,15 @@
 name: Tests::Linux::x86_64
 on:
+  workflow_call:
+    inputs:
+      lightning-gpu-version:
+        type: string
+        required: true
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+      pennylane-version:
+        type: string
+        required: true
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   release:
   push:
     branches:
@@ -47,6 +57,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-gpu-version == 'stable' && 0 || 1 }}
+
+      - name: Switch to stable build of Lightning-GPU
+        if: inputs.lightning-gpu-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -110,6 +127,10 @@ jobs:
           module load mpich
           mpiexec --version
           module unload mpich
+
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and run unit tests
         run: |
@@ -180,8 +201,15 @@ jobs:
       max-parallel: 1
 
     steps:
-      - name: Checkout pennyLane-lightning-gpu
+      - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-gpu-version == 'stable' && 0 || 1 }}
+
+      - name: Switch to stable build of Lightning-GPU
+        if: inputs.lightning-gpu-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -226,9 +254,12 @@ jobs:
           python -m pip install pip~=22.0
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov
           # Sync with latest master branches
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
-          
+
+      - name: Install Latest PennyLane
+        if: ${{ inputs.pennylane-version == 'latest' }}
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Build and install package
         env: 
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -27,6 +27,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  event_name:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ github.event_name }}
   cpp_mpich_tests:
     if: contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call'
 

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -21,7 +21,7 @@ env:
   GCC_VERSION: 11
   OMP_NUM_THREADS: "2"
   CI_CUDA_ARCH: 86
-  MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') }}
+  MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call' }}
 
 concurrency:
   group: gpu-test-mpich-${{ github.ref }}

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -1,5 +1,15 @@
 name: Tests::Linux::x86_64_MPICH
 on:
+  workflow_call:
+    inputs:
+      lightning-gpu-version:
+        type: string
+        required: true
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+      pennylane-version:
+        type: string
+        required: true
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   release:
   push:
     branches:
@@ -14,7 +24,7 @@ env:
   MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') }}
 
 concurrency:
-  group: gpu-test-${{ github.ref }}
+  group: gpu-test-mpich-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -47,6 +57,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-gpu-version == 'stable' && 0 || 1 }}
+
+      - name: Switch to stable build of Lightning-GPU
+        if: inputs.lightning-gpu-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -114,6 +131,10 @@ jobs:
           which mpicc
           which mpiexec
           module unload mpich
+
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and run unit tests with OpenMPI backend
         run: |
@@ -202,6 +223,13 @@ jobs:
     steps:
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3
+        with:
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-gpu-version == 'stable' && 0 || 1 }}
+
+      - name: Switch to stable build of Lightning-GPU
+        if: inputs.lightning-gpu-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         id: setup_python
@@ -252,9 +280,12 @@ jobs:
           python -m pip install pip~=22.0
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov mpi4py
           # Sync with latest master branches
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
-          
+
+      - name: Install Latest PennyLane
+        if: ${{ inputs.pennylane-version == 'latest' }}
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Build and install package (OpenMPI backend)
         env: 
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -23,7 +23,7 @@ env:
   CI_CUDA_ARCH: 86
 
 concurrency:
-  group: gpu-test-mpich-${{ github.ref }}
+  group: gpu-test-mpich-${{ github.ref }}-${{ inputs.lightning-gpu-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  #pull_request:
 
 env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning_gpu --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native" 

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -21,7 +21,6 @@ env:
   GCC_VERSION: 11
   OMP_NUM_THREADS: "2"
   CI_CUDA_ARCH: 86
-  MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call' }}
 
 concurrency:
   group: gpu-test-mpich-${{ github.ref }}
@@ -29,7 +28,7 @@ concurrency:
 
 jobs:
   cpp_mpich_tests:
-    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call'
 
     runs-on:
       - self-hosted
@@ -199,7 +198,7 @@ jobs:
 
 
   python_mpich_tests:
-    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call'
 
     runs-on:
       - self-hosted

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - main
-  #pull_request:
+  pull_request:
 
 env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning_gpu --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native" 
@@ -27,10 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  event_name:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ${{ github.event_name }}
   cpp_mpich_tests:
     if: contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call'
 

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -28,28 +28,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  set_runs_on_values:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set GPU Label
-        id: gpu_label
-        run: |
-          if [[ "${{ env.MULTI_GPU_SUPPORT_REQUIRED }}" == "true" ]]; then
-            echo "gpu_type=multi-gpu" >> $GITHUB_OUTPUT
-          else
-            echo "gpu_type=gpu" >> $GITHUB_OUTPUT
-          fi
-
-    outputs:
-      gpu_type: ${{ steps.gpu_label.outputs.gpu_type }}
-      runs-on: '["self-hosted", "linux", "x64", "ubuntu-22.04", "${{ steps.gpu_label.outputs.gpu_type }}"]'
-
   cpp_mpich_tests:
-    needs:
-      - set_runs_on_values
+    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
 
-    runs-on: ${{ fromJson(needs.set_runs_on_values.outputs.runs-on) }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - ubuntu-22.04
+      - multi-gpu
 
     strategy:
       max-parallel: 1
@@ -212,10 +199,14 @@ jobs:
 
 
   python_mpich_tests:
-    needs:
-      - set_runs_on_values
+    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
 
-    runs-on: ${{ fromJson(needs.set_runs_on_values.outputs.runs-on) }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - ubuntu-22.04
+      - multi-gpu
 
     strategy:
       max-parallel: 1

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -269,6 +269,10 @@ jobs:
           echo "PIP Path => $pip_path"
           echo "pip=$pip_path" >> $GITHUB_OUTPUT
 
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+        
       - name: Install required packages (OpenMPI backend)
         run: |
           source /etc/profile.d/modules.sh
@@ -281,10 +285,6 @@ jobs:
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov mpi4py
           # Sync with latest master branches
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
-
-      - name: Install Latest PennyLane
-        if: ${{ inputs.pennylane-version == 'latest' }}
-        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and install package (OpenMPI backend)
         env: 

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -272,7 +272,7 @@ jobs:
       - name: Install Latest PennyLane
         if: inputs.pennylane-version == 'latest'
         run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
-        
+
       - name: Install required packages (OpenMPI backend)
         run: |
           source /etc/profile.d/modules.sh

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -14,7 +14,7 @@ env:
   MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') }}
 
 concurrency:
-  group: gpu-test-${{ github.ref }}
+  group: gpu-test-openmpi-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -11,7 +11,6 @@ env:
   GCC_VERSION: 11
   OMP_NUM_THREADS: "2"
   CI_CUDA_ARCH: 86
-  MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call' }}
 
 concurrency:
   group: gpu-test-openmpi-${{ github.ref }}
@@ -19,7 +18,7 @@ concurrency:
 
 jobs:
   cpp_openmpi_tests:
-    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call'
 
     runs-on:
       - self-hosted
@@ -178,7 +177,7 @@ jobs:
 
 
   python_openmpi_tests:
-    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call'
 
     runs-on:
       - self-hosted

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -13,7 +13,7 @@ env:
   CI_CUDA_ARCH: 86
 
 concurrency:
-  group: gpu-test-openmpi-${{ github.ref }}
+  group: gpu-test-openmpi-${{ github.ref }}-${{ inputs.lightning-gpu-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -11,7 +11,7 @@ env:
   GCC_VERSION: 11
   OMP_NUM_THREADS: "2"
   CI_CUDA_ARCH: 86
-  MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') }}
+  MULTI_GPU_SUPPORT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_call' }}
 
 concurrency:
   group: gpu-test-openmpi-${{ github.ref }}

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -18,28 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  set_runs_on_values:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set GPU Label
-        id: gpu_label
-        run: |
-          if [[ "${{ env.MULTI_GPU_SUPPORT_REQUIRED }}" == "true" ]]; then
-            echo "gpu_type=multi-gpu" >> $GITHUB_OUTPUT
-          else
-            echo "gpu_type=gpu" >> $GITHUB_OUTPUT
-          fi
-
-    outputs:
-      gpu_type: ${{ steps.gpu_label.outputs.gpu_type }}
-      runs-on: '["self-hosted", "linux", "x64", "ubuntu-22.04", "${{ steps.gpu_label.outputs.gpu_type }}"]'
-
   cpp_openmpi_tests:
-    needs:
-      - set_runs_on_values
+    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
 
-    runs-on: ${{ fromJson(needs.set_runs_on_values.outputs.runs-on) }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - ubuntu-22.04
+      - multi-gpu
 
     strategy:
       max-parallel: 1
@@ -191,10 +178,14 @@ jobs:
 
 
   python_openmpi_tests:
-    needs:
-      - set_runs_on_values
+    if: env.MULTI_GPU_SUPPORT_REQUIRED == 'true'
 
-    runs-on: ${{ fromJson(needs.set_runs_on_values.outputs.runs-on) }}
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - ubuntu-22.04
+      - multi-gpu
 
     strategy:
       max-parallel: 1


### PR DESCRIPTION
**Context:**
This PR adds 4 new workflows who's result can be tracked in the plugin-test-matrix.

**Description of the Change:**
A new `workflow_call` event was added to the linux_x86 and linux_x86_mpich workflows. The version of lightning-gpu and pennylane that is to be installed can now be passed. The behavior is as follows:

- lightning-gpu-version:
  - `latest` -> The current workflow is used as-is. Since it uses the latest commit on main by default, no further changes are necessary.
  - `stable` -> The most recent git-tag is checked out.

- pennylane-version:
  - `latest` -> PennyLane is installed from master branch prior to LGPU installation
  - `stable` -> LGPU is installed as per normal and the version specified in requirements.txt should take over.

**Benefits:**
Adds ability to display the results of these workflows on the plugin test matrix.

**Possible Drawbacks:**

**Related GitHub Issues:**
