### PR TITLE
Switch to GA4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,7 +122,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "PennyLane-Lightning-GPU"
-copyright = "Copyright 2022"
+copyright = "Copyright 2023"
 author = "Xanadu Inc."
 
 add_module_names = False
@@ -189,7 +189,7 @@ html_theme_options = {
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks "
         "of Google Inc."
     ],
-    "google_analytics_tracking_id": "UA-130507810-1",
+    "google_analytics_tracking_id": "G-C480Z9JL0D",
     "toc_overview": True
 }
 


### PR DESCRIPTION
Google is deprecating Universal Analytics on July 1st. This PR replaces that tag with the newer GA4 tag.