### PR TITLE
Implements qml.Rot with single cuSV API

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Improvements
 
+* Optimizes the single qubit rotation gate by using a single cuStateVector API call instead of separate Pauli gate applications. Pull Request TBD
+
 ### Documentation
 
 ### Bug fixes
@@ -18,7 +20,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Shuli Shu
+David Clark (NVIDIA), Shuli Shu
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Improvements
 
-* Optimizes the single qubit rotation gate by using a single cuStateVector API call instead of separate Pauli gate applications. Pull Request TBD
+ * Optimizes the single qubit rotation gate by using a single cuStateVector API call instead of separate Pauli gate applications. 
+ [(#132)] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/132)
 
 ### Documentation
 

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaMPI.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc. and contributors.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -385,13 +385,13 @@ class StateVectorCudaMPI
                                      adjoint);
         } else if (opName == "Rot" || opName == "CRot") {
             if (adjoint) {
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[2], true);
-                applyParametricPauliGate({"RY"}, ctrls, tgts, params[1], true);
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[0], true);
+                auto rot_matrix =
+                    cuGates::getRot<CFP_t>(params[2], params[1], params[0]);
+                applyHostMatrixGate(rot_matrix, ctrls, tgts, true);
             } else {
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[0], false);
-                applyParametricPauliGate({"RY"}, ctrls, tgts, params[1], false);
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[2], false);
+                auto rot_matrix =
+                    cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+                applyHostMatrixGate(rot_matrix, ctrls, tgts, false);
             }
         } else if (par_gates_.find(opName) != par_gates_.end()) {
             par_gates_.at(opName)(wires, adjoint, params);
@@ -559,15 +559,9 @@ class StateVectorCudaMPI
     }
     inline void applyRot(const std::vector<std::size_t> &wires, bool adjoint,
                          Precision param0, Precision param1, Precision param2) {
-        if (!adjoint) {
-            applyRZ(wires, false, param0);
-            applyRY(wires, false, param1);
-            applyRZ(wires, false, param2);
-        } else {
-            applyRZ(wires, true, param2);
-            applyRY(wires, true, param1);
-            applyRZ(wires, true, param0);
-        }
+        const std::string opName = "Rot";
+        const std::vector<Precision> params = {param0, param1, param2};
+        applyOperation(opName, wires, adjoint, params);
     }
     inline void applyRot(const std::vector<std::size_t> &wires, bool adjoint,
                          const std::vector<Precision> &params) {
@@ -636,15 +630,9 @@ class StateVectorCudaMPI
     inline void applyCRot(const std::vector<std::size_t> &wires, bool adjoint,
                           Precision param0, Precision param1,
                           Precision param2) {
-        if (!adjoint) {
-            applyCRZ(wires, false, param0);
-            applyCRY(wires, false, param1);
-            applyCRZ(wires, false, param2);
-        } else {
-            applyCRZ(wires, true, param2);
-            applyCRY(wires, true, param1);
-            applyCRZ(wires, true, param0);
-        }
+        const std::string opName = "CRot";
+        const std::vector<Precision> params = {param0, param1, param2};
+        applyOperation(opName, wires, adjoint, params);
     }
 
     inline void applyCRX(const std::vector<std::size_t> &wires, bool adjoint,

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Xanadu Quantum Technologies Inc. and contributors.
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc. and contributors.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -212,13 +212,13 @@ class StateVectorCudaManaged
                                      adjoint);
         } else if (opName == "Rot" || opName == "CRot") {
             if (adjoint) {
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[2], true);
-                applyParametricPauliGate({"RY"}, ctrls, tgts, params[1], true);
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[0], true);
+                auto rot_matrix =
+                    cuGates::getRot<CFP_t>(params[2], params[1], params[0]);
+                applyHostMatrixGate(rot_matrix, ctrls, tgts, true);
             } else {
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[0], false);
-                applyParametricPauliGate({"RY"}, ctrls, tgts, params[1], false);
-                applyParametricPauliGate({"RZ"}, ctrls, tgts, params[2], false);
+                auto rot_matrix =
+                    cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+                applyHostMatrixGate(rot_matrix, ctrls, tgts, false);
             }
         } else if (par_gates_.find(opName) != par_gates_.end()) {
             par_gates_.at(opName)(wires, adjoint, params);
@@ -387,15 +387,9 @@ class StateVectorCudaManaged
     }
     inline void applyRot(const std::vector<std::size_t> &wires, bool adjoint,
                          Precision param0, Precision param1, Precision param2) {
-        if (!adjoint) {
-            applyRZ(wires, false, param0);
-            applyRY(wires, false, param1);
-            applyRZ(wires, false, param2);
-        } else {
-            applyRZ(wires, true, param2);
-            applyRY(wires, true, param1);
-            applyRZ(wires, true, param0);
-        }
+        const std::string opName = "Rot";
+        const std::vector<Precision> params = {param0, param1, param2};
+        applyOperation(opName, wires, adjoint, params);
     }
     inline void applyRot(const std::vector<std::size_t> &wires, bool adjoint,
                          const std::vector<Precision> &params) {
@@ -464,15 +458,9 @@ class StateVectorCudaManaged
     inline void applyCRot(const std::vector<std::size_t> &wires, bool adjoint,
                           Precision param0, Precision param1,
                           Precision param2) {
-        if (!adjoint) {
-            applyCRZ(wires, false, param0);
-            applyCRY(wires, false, param1);
-            applyCRZ(wires, false, param2);
-        } else {
-            applyCRZ(wires, true, param2);
-            applyCRY(wires, true, param1);
-            applyCRZ(wires, true, param0);
-        }
+        const std::string opName = "CRot";
+        const std::vector<Precision> params = {param0, param1, param2};
+        applyOperation(opName, wires, adjoint, params);
     }
 
     inline void applyCRX(const std::vector<std::size_t> &wires, bool adjoint,


### PR DESCRIPTION
**Context:**

This PR optimizes the single qubit rotation gate

**Description of the Change:**

The arbitrary single qubit rotation gate ([`qml.Rot`](https://docs.pennylane.ai/en/stable/code/api/pennylane.Rot.html#qml-rot)) is implemented by decomposing the gate into RZ and RY gates with the `lightning.gpu` backend. This leads to three cuStateVec kernels being launched on the GPU. This PR switches to directly using the gate matrix formula in the documentation and applying the rotation with a single API call via the applyHostMatrixGate function. The host API is used to avoid caching the rotation gates on the device as the parameters may change often. This improves the performance of the gate because only one kernel is needed.

**Benefits:**

Improved performance for `qml.Rot`

**Possible Drawbacks:**

None that I am aware of.

**Related GitHub Issues:**

None