### PR TITLE
Pin lightning.qubit dep to v0.31.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking changes
  
- * Rename `QubistStateVector` to `StatePrep` in the `LightningGPU` class.
+ * Rename `QubitStateVector` to `StatePrep` in the `LightningGPU` class.
  [#134] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/134)
 
 * Remove support for Python 3.8.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
  * Rename `QubistStateVector` to `StatePrep` in the `LightningGPU` class.
  [#134] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/134)
 
-* Remove suport for Python 3.9.
+* Remove support for Python 3.8.
   [(#135)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/135)
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
  [(#127)] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/127)
 
 ### Breaking changes
+ 
+ * Rename `QubistStateVector` to `StatePrep` in the `LightningGPU` class.
+ [#134] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/134)
 
 * Remove suport for Python 3.9.
   [(#135)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/135)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### Breaking changes
 
+* Remove suport for Python 3.9.
+  [(#135)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/135)
+
 ### Improvements
 
  * Optimizes the single qubit rotation gate by using a single cuStateVector API call instead of separate Pauli gate applications. 
@@ -15,6 +18,10 @@
 ### Documentation
 
 ### Bug fixes
+
+* Pin `lightning.qubit` build version to v0.31.0 due to new package architecture.
+  [(#135)](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/135)
+
 * `apply` no longer mutates the inputted list of operations and 
  add the missing `_dp` to the LightningGPU class with single GPU backend.
  [(#133)] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/133)

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::x86_64
 
 # **What it does**: Builds python wheels for Linux (ubuntu-latest) architecture x86_64 and store it as artifacts.
-#                   Python versions: 3.8, 3.9, 3.10, 3.11.
+#                   Python versions: 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning-gpu installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-latest]
         arch: [x86_64]
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version) }}
-    name: ${{ matrix.os }} (Python ${{ fromJson('{"cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }} (Python ${{ fromJson('{"cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel~=2.11.0

--- a/.github/workflows/build_wheel_manylinux2014.yml
+++ b/.github/workflows/build_wheel_manylinux2014.yml
@@ -56,7 +56,7 @@ jobs:
 
           CIBW_SKIP: "*-musllinux*"
 
-          CIBW_CONFIG_SETTINGS: --global-option=build_ext --global-option=--define="CMAKE_CXX_COMPILER=$(which g++-11);CMAKE_C_COMPILER=$(which gcc-11);LIGHTNING_RELEASE_TAG=master"
+          CIBW_CONFIG_SETTINGS: --global-option=build_ext --global-option=--define="CMAKE_CXX_COMPILER=$(which g++-11);CMAKE_C_COMPILER=$(which gcc-11);LIGHTNING_RELEASE_TAG=v0.31.0"
 
           # Python build settings
           CIBW_BEFORE_BUILD: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run:

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -69,7 +69,7 @@ jobs:
         id: setup_python
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # Since the self-hosted runner can be re-used. It is best to set up all package
       # installations in a virtual environment that gets cleaned at the end of each workflow run
@@ -215,7 +215,7 @@ jobs:
         id: setup_python
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # Since the self-hosted runner can be re-used. It is best to set up all package
       # installations in a virtual environment that gets cleaned at the end of each workflow run

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -259,7 +259,7 @@ jobs:
           python -m pip install pip~=22.0
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov
           # Sync with latest master branches
-          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning==0.32.0.dev5 --pre --force-reinstall --no-deps
 
       - name: Build and install package
         env: 

--- a/.github/workflows/tests_linux_x86.yml
+++ b/.github/workflows/tests_linux_x86.yml
@@ -138,7 +138,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DPLLGPU_BUILD_TESTS=ON \
               -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})" \
-              -DLIGHTNING_RELEASE_TAG="master" \
+              -DLIGHTNING_RELEASE_TAG="v0.31.0" \
               -DCMAKE_CUDA_COMPILER="/usr/local/cuda/bin/nvcc" \
               -DCMAKE_CUDA_ARCHITECTURES="86" \
               -DPython_EXECUTABLE:FILE="${{ steps.python_path.outputs.python }}" \
@@ -162,7 +162,7 @@ jobs:
               -DPLLGPU_BUILD_TESTS=ON \
               -DPLLGPU_ENABLE_COVERAGE=ON \
               -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})" \
-              -DLIGHTNING_RELEASE_TAG="master" \
+              -DLIGHTNING_RELEASE_TAG="v0.31.0" \
               -DCMAKE_CUDA_COMPILER="/usr/local/cuda/bin/nvcc" \
               -DCMAKE_CUDA_ARCHITECTURES="86" \
               -DPython_EXECUTABLE:FILE="${{ steps.python_path.outputs.python }}" \
@@ -265,7 +265,7 @@ jobs:
         env: 
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")
         run: |
-          python setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});LIGHTNING_RELEASE_TAG=master;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }};Python_EXECUTABLE=${{ steps.python_path.outputs.python }}"
+          python setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});LIGHTNING_RELEASE_TAG=v0.31.0;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }};Python_EXECUTABLE=${{ steps.python_path.outputs.python }}"
           python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-GPU unit tests

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -55,7 +55,7 @@ jobs:
         id: setup_python
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # Since the self-hosted runner can be re-used. It is best to set up all package
       # installations in a virtual environment that gets cleaned at the end of each workflow run
@@ -225,7 +225,7 @@ jobs:
         id: setup_python
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # Since the self-hosted runner can be re-used. It is best to set up all package
       # installations in a virtual environment that gets cleaned at the end of each workflow run

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -136,7 +136,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DPLLGPU_BUILD_TESTS=ON \
               -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})" \
-              -DLIGHTNING_RELEASE_TAG="master" \
+              -DLIGHTNING_RELEASE_TAG="v0.31.0" \
               -DCMAKE_CUDA_COMPILER="/usr/local/cuda/bin/nvcc" \
               -DCMAKE_CUDA_ARCHITECTURES="86" \
               -DPython_EXECUTABLE:FILE="${{ steps.python_path.outputs.python }}" \
@@ -168,7 +168,7 @@ jobs:
               -DPLLGPU_BUILD_TESTS=ON \
               -DPLLGPU_ENABLE_COVERAGE=ON \
               -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})" \
-              -DLIGHTNING_RELEASE_TAG="master" \
+              -DLIGHTNING_RELEASE_TAG="v0.31.0" \
               -DCMAKE_CUDA_COMPILER="/usr/local/cuda/bin/nvcc" \
               -DCMAKE_CUDA_ARCHITECTURES="86" \
               -DPython_EXECUTABLE:FILE="${{ steps.python_path.outputs.python }}" \
@@ -281,7 +281,7 @@ jobs:
         env: 
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")
         run: |
-          python setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});CMAKE_PREFIX_PATH=/opt/mpi/mpich;PLLGPU_ENABLE_MPI=On;LIGHTNING_RELEASE_TAG=master;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }};Python_EXECUTABLE=${{ steps.python_path.outputs.python }}"
+          python setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});CMAKE_PREFIX_PATH=/opt/mpi/mpich;PLLGPU_ENABLE_MPI=On;LIGHTNING_RELEASE_TAG=v0.31.0;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }};Python_EXECUTABLE=${{ steps.python_path.outputs.python }}"
           python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-GPU unit tests (MPICH backend)

--- a/.github/workflows/tests_linux_x86_mpich.yml
+++ b/.github/workflows/tests_linux_x86_mpich.yml
@@ -275,7 +275,7 @@ jobs:
           python -m pip install pip~=22.0
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov mpi4py
           # Sync with latest master branches
-          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning==0.32.0.dev5 --pre --force-reinstall --no-deps
           
       - name: Build and install package (MPICH backend)
         env: 

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -247,7 +247,7 @@ jobs:
           python -m pip install pip~=22.0
           python -m pip install ninja cmake custatevec-cu11 pytest pytest-mock flaky pytest-cov mpi4py
           # Sync with latest master branches
-          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning==0.32.0.dev5 --pre --force-reinstall --no-deps
           
       - name: Build and install package (OpenMPI backend)
         env: 

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -38,7 +38,7 @@ jobs:
         id: setup_python
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # Since the self-hosted runner can be re-used. It is best to set up all package
       # installations in a virtual environment that gets cleaned at the end of each workflow run
@@ -197,7 +197,7 @@ jobs:
         id: setup_python
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # Since the self-hosted runner can be re-used. It is best to set up all package
       # installations in a virtual environment that gets cleaned at the end of each workflow run

--- a/.github/workflows/tests_linux_x86_openmpi.yml
+++ b/.github/workflows/tests_linux_x86_openmpi.yml
@@ -115,7 +115,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DPLLGPU_BUILD_TESTS=ON \
               -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})" \
-              -DLIGHTNING_RELEASE_TAG="master" \
+              -DLIGHTNING_RELEASE_TAG="v0.31.0" \
               -DCMAKE_CUDA_COMPILER="/usr/local/cuda/bin/nvcc" \
               -DCMAKE_CUDA_ARCHITECTURES="86" \
               -DPython_EXECUTABLE:FILE="${{ steps.python_path.outputs.python }}" \
@@ -147,7 +147,7 @@ jobs:
               -DPLLGPU_BUILD_TESTS=ON \
               -DPLLGPU_ENABLE_COVERAGE=ON \
               -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})" \
-              -DLIGHTNING_RELEASE_TAG="master" \
+              -DLIGHTNING_RELEASE_TAG="v0.31.0" \
               -DCMAKE_CUDA_COMPILER="/usr/local/cuda/bin/nvcc" \
               -DCMAKE_CUDA_ARCHITECTURES="86" \
               -DPython_EXECUTABLE:FILE="${{ steps.python_path.outputs.python }}" \
@@ -253,7 +253,7 @@ jobs:
         env: 
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')")
         run: |
-          python setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});CMAKE_PREFIX_PATH=/opt/mpi/openmpi;PLLGPU_ENABLE_MPI=On;LIGHTNING_RELEASE_TAG=master;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }};Python_EXECUTABLE=${{ steps.python_path.outputs.python }}"
+          python setup.py build_ext -i --define="CMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }});CMAKE_PREFIX_PATH=/opt/mpi/openmpi;PLLGPU_ENABLE_MPI=On;LIGHTNING_RELEASE_TAG=v0.31.0;CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc;CMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }};Python_EXECUTABLE=${{ steps.python_path.outputs.python }}"
           python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-GPU unit tests (OpenMPI backend)

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ python:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
   apt_packages:
     - cmake
     - build-essential

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ FetchContent_MakeAvailable(pybind11)
 
 # Add PennyLane-Lightning
 if (NOT DEFINED LIGHTNING_RELEASE_TAG)
-  set(LIGHTNING_RELEASE_TAG "latest_release")
+  set(LIGHTNING_RELEASE_TAG "v0.31.0")
 endif()
 
 # Disable non-required lengthy build-steps from PennyLane Lightning

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifndef CUQUANTUM_SDK
 	@test $(CUQUANTUM_SDK)
 endif
 ifndef PYTHON3
-	@echo "To install PennyLane-Lightning-GPU you must have Python 3.8+ installed."
+	@echo "To install PennyLane-Lightning-GPU you must have Python 3.9+ installed."
 endif
 	$(PYTHON) setup.py build_ext --cuquantum=$(CUQUANTUM_SDK) --verbose
 	$(PYTHON) setup.py install

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Features
 Installation
 ============
 
-PennyLane-Lightning-GPU requires Python version 3.8 and above. It can be installed using ``pip``:
+PennyLane-Lightning-GPU requires Python version 3.9 and above. It can be installed using ``pip``:
 
 .. code-block:: console
 
@@ -82,7 +82,7 @@ To build using Docker, run the following from the project root directory:
 
     docker build . -f ./docker/Dockerfile -t "lightning-gpu-wheels"
 
-This will build a Python wheel for Python 3.8 up to 3.11 inclusive, and be manylinux2014 (glibc 2.17) compatible.
+This will build a Python wheel for Python 3.9 up to 3.11 inclusive, and be manylinux2014 (glibc 2.17) compatible.
 To acquire the built wheels, use:
 
 .. code-block:: console

--- a/doc/devices.rst
+++ b/doc/devices.rst
@@ -46,7 +46,7 @@ Supported operations and observables
     ~pennylane.PauliZ
     ~pennylane.PhaseShift
     ~pennylane.ControlledPhaseShift
-    ~pennylane.QubitStateVector
+    ~pennylane.StatePrep
     ~pennylane.Rot
     ~pennylane.RX
     ~pennylane.RY

--- a/mpitests/test_adjoint_jacobian.py
+++ b/mpitests/test_adjoint_jacobian.py
@@ -188,7 +188,7 @@ class TestAdjointJacobian:
         dev_cpu = qml.device("default.qubit", wires=3)
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
+            qml.StatePrep(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -218,7 +218,7 @@ class TestAdjointJacobian:
         params = np.array([theta, theta**3, np.sqrt(2) * theta])
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
+            qml.StatePrep(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -760,7 +760,7 @@ def test_qchem_expvalcost_correct(request):
 
 def circuit_ansatz(params, wires):
     """Circuit ansatz containing all the parametrized gates"""
-    qml.QubitStateVector(unitary_group.rvs(2**6, random_state=0)[0], wires=wires)
+    qml.StatePrep(unitary_group.rvs(2**6, random_state=0)[0], wires=wires)
     qml.RX(params[0], wires=wires[0])
     qml.RY(params[1], wires=wires[1])
     qml.adjoint(qml.RX(params[2], wires=wires[2]))

--- a/mpitests/test_apply.py
+++ b/mpitests/test_apply.py
@@ -72,7 +72,7 @@ def apply_operation_gates_qnode_param(tol, operation, par, Wires):
     )
 
     def circuit(*params):
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         operation(*params, wires=Wires)
         return qml.state()
 
@@ -105,7 +105,7 @@ def apply_operation_gates_apply_param(tol, operation, par, Wires):
 
     @qml.qnode(dev_cpu)
     def circuit(*params):
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         operation(*params, wires=Wires)
         return qml.state()
 
@@ -153,7 +153,7 @@ def apply_operation_gates_qnode_nonparam(tol, operation, Wires):
     )
 
     def circuit():
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         operation(wires=Wires)
         return qml.state()
 
@@ -186,7 +186,7 @@ def apply_operation_gates_apply_nonparam(tol, operation, Wires):
 
     @qml.qnode(dev_cpu)
     def circuit():
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         operation(wires=Wires)
         return qml.state()
 
@@ -225,7 +225,7 @@ def expval_single_wire_no_param(tol, obs):
     dev_gpumpi = qml.device("lightning.gpu", wires=num_wires, mpi=True, c_dtype=np.complex128)
 
     def circuit():
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         return qml.expval(obs)
 
     cpu_qnode = qml.QNode(circuit, dev_cpu)
@@ -252,7 +252,7 @@ def apply_probs_nonparam(tol, operation, GateWires, Wires):
     dev_gpumpi = qml.device("lightning.gpu", wires=num_wires, mpi=True, c_dtype=np.complex128)
 
     def circuit():
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         operation(wires=GateWires)
         return qml.probs(wires=Wires)
 
@@ -292,7 +292,7 @@ def apply_probs_param(tol, operation, par, GateWires, Wires):
     dev_gpumpi = qml.device("lightning.gpu", wires=num_wires, mpi=True, c_dtype=np.complex128)
 
     def circuit():
-        qml.QubitStateVector(state_vector, wires=range(num_wires))
+        qml.StatePrep(state_vector, wires=range(num_wires))
         operation(*par, wires=GateWires)
         return qml.probs(wires=Wires)
 
@@ -501,7 +501,7 @@ class TestApply:
         dev_gpumpi = qml.device("lightning.gpu", wires=num_wires, mpi=True, c_dtype=np.complex128)
 
         def circuit():
-            qml.QubitStateVector(par, wires=Wires)
+            qml.StatePrep(par, wires=Wires)
             return qml.state()
 
         cpu_qnode = qml.QNode(circuit, dev_cpu)
@@ -1152,7 +1152,7 @@ class TestProbs:
 
 def circuit_ansatz(params, wires):
     """Circuit ansatz containing all the parametrized gates"""
-    qml.QubitStateVector(unitary_group.rvs(2**numQubits, random_state=0)[0], wires=wires)
+    qml.StatePrep(unitary_group.rvs(2**numQubits, random_state=0)[0], wires=wires)
     qml.RX(params[0], wires=wires[0])
     qml.RY(params[1], wires=wires[1])
     qml.adjoint(qml.RX(params[2], wires=wires[2]))

--- a/pennylane_lightning_gpu/_serialize.py
+++ b/pennylane_lightning_gpu/_serialize.py
@@ -24,7 +24,7 @@ from pennylane import (
     PauliY,
     PauliZ,
     Identity,
-    QubitStateVector,
+    StatePrep,
     Rot,
 )
 from pennylane.operation import Tensor
@@ -286,7 +286,7 @@ def _serialize_ops(
     sv_py = LightningGPU_C64 if use_csingle else LightningGPU_C128
 
     for o in tape.operations:
-        if isinstance(o, (BasisState, QubitStateVector)):
+        if isinstance(o, (BasisState, StatePrep)):
             uses_stateprep = True
             continue
         elif isinstance(o, Rot):

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -27,6 +27,7 @@ from pennylane import (
     math,
     QubitDevice,
     BasisState,
+    QubitStateVector,
     StatePrep,
     DeviceError,
     Projector,

--- a/pennylane_lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning_gpu/lightning_gpu.py
@@ -27,7 +27,7 @@ from pennylane import (
     math,
     QubitDevice,
     BasisState,
-    QubitStateVector,
+    StatePrep,
     DeviceError,
     Projector,
     Hermitian,
@@ -141,7 +141,7 @@ _name_map = {"PauliX": "X", "PauliY": "Y", "PauliZ": "Z", "Identity": "I"}
 allowed_operations = {
     "Identity",
     "BasisState",
-    "QubitStateVector",
+    "StatePrep",
     "QubitUnitary",
     "ControlledQubitUnitary",
     "MultiControlledX",
@@ -554,7 +554,7 @@ if CPP_BINARY_AVAILABLE:
         def apply(self, operations, **kwargs):
             # State preparation is currently done in Python
             if operations:  # make sure operations[0] exists
-                if isinstance(operations[0], QubitStateVector):
+                if isinstance(operations[0], StatePrep):
                     self._apply_state_vector_GPU(
                         operations[0].parameters[0].copy(), operations[0].wires
                     )
@@ -564,7 +564,7 @@ if CPP_BINARY_AVAILABLE:
                     operations = operations[1:]
 
             for operation in operations:
-                if isinstance(operation, (QubitStateVector, BasisState)):
+                if isinstance(operation, (StatePrep, BasisState)):
                     raise DeviceError(
                         "Operation {} cannot be used after other Operations have already been "
                         "applied on a {} device.".format(operation.name, self.short_name)
@@ -678,7 +678,7 @@ if CPP_BINARY_AVAILABLE:
                 # get op_idx-th operator among differentiable operators
                 op, _, _ = tape.get_operation(op_idx)
 
-                if isinstance(op, Operation) and not isinstance(op, (BasisState, QubitStateVector)):
+                if isinstance(op, Operation) and not isinstance(op, (BasisState, StatePrep)):
                     # We now just ignore non-op or state preps
                     tp_shift.append(tp)
                     record_tp_rows.append(all_params)

--- a/pennylane_lightning_gpu/src/algorithms/AdjointDiffGPU.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/AdjointDiffGPU.hpp
@@ -560,7 +560,7 @@ template <class T = double> class AdjointJacobianGPU {
             PL_ABORT_IF(ops.getOpsParams()[op_idx].size() > 1,
                         "The operation is not supported using the adjoint "
                         "differentiation method");
-            if ((ops_name[op_idx] == "QubitStateVector") ||
+            if ((ops_name[op_idx] == "StatePrep") ||
                 (ops_name[op_idx] == "BasisState")) {
                 continue;
             }

--- a/pennylane_lightning_gpu/src/algorithms/AdjointDiffGPUMPI.hpp
+++ b/pennylane_lightning_gpu/src/algorithms/AdjointDiffGPUMPI.hpp
@@ -300,7 +300,7 @@ class AdjointJacobianGPUMPI {
                 PL_ABORT_IF(ops.getOpsParams()[op_idx].size() > 1,
                             "The operation is not supported using the adjoint "
                             "differentiation method");
-                if ((ops_name[op_idx] == "QubitStateVector") ||
+                if ((ops_name[op_idx] == "StatePrep") ||
                     (ops_name[op_idx] == "BasisState")) {
                     continue;
                 }
@@ -396,7 +396,7 @@ class AdjointJacobianGPUMPI {
             PL_ABORT_IF(ops.getOpsParams()[op_idx].size() > 1,
                         "The operation is not supported using the adjoint "
                         "differentiation method");
-            if ((ops_name[op_idx] == "QubitStateVector") ||
+            if ((ops_name[op_idx] == "StatePrep") ||
                 (ops_name[op_idx] == "BasisState")) {
                 continue;
             }

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -196,7 +196,7 @@ class TestAdjointJacobian:
         """Tests that the automatic gradients of Pauli rotations are correct."""
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
+            qml.StatePrep(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -214,7 +214,7 @@ class TestAdjointJacobian:
         params = np.array([theta, theta**3, np.sqrt(2) * theta])
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
+            qml.StatePrep(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -687,7 +687,7 @@ def test_qchem_expvalcost_correct():
 
 def circuit_ansatz(params, wires):
     """Circuit ansatz containing all the parametrized gates"""
-    qml.QubitStateVector(unitary_group.rvs(2**4, random_state=0)[0], wires=wires)
+    qml.StatePrep(unitary_group.rvs(2**4, random_state=0)[0], wires=wires)
     qml.RX(params[0], wires=wires[0])
     qml.RY(params[1], wires=wires[1])
     qml.adjoint(qml.RX(params[2], wires=wires[2]))

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -223,16 +223,16 @@ class TestApply:
             (qml.BasisState, [0, 0, 1, 0], [1, 0]),
             (qml.BasisState, [0, 0, 1, 0], [1, 0]),
             (qml.BasisState, [0, 0, 0, 1], [1, 1]),
-            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-            (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
+            (qml.StatePrep, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.StatePrep, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.StatePrep, [0, 0, 0, 1], [0, 0, 0, 1]),
             (
-                qml.QubitStateVector,
+                qml.StatePrep,
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
             ),
             (
-                qml.QubitStateVector,
+                qml.StatePrep,
                 [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
                 [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
             ),
@@ -480,24 +480,24 @@ class TestApply:
     def test_apply_errors_qubit_state_vector(self, qubit_device_2_wires):
         """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
         with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
-            qubit_device_2_wires.apply([qml.QubitStateVector(np.array([1, -1]), wires=[0])])
+            qubit_device_2_wires.apply([qml.StatePrep(np.array([1, -1]), wires=[0])])
 
         with pytest.raises(
             ValueError,
             match=r"State vector must have shape \(2\*\*wires,\) or \(batch_size, 2\*\*wires\).",
         ):
             p = np.array([1, 0, 1, 1, 0]) / np.sqrt(3)
-            qubit_device_2_wires.apply([qml.QubitStateVector(p, wires=[0, 1])])
+            qubit_device_2_wires.apply([qml.StatePrep(p, wires=[0, 1])])
 
         with pytest.raises(
             DeviceError,
-            match="Operation QubitStateVector cannot be used after other Operations have already been applied ",
+            match="Operation StatePrep cannot be used after other Operations have already been applied ",
         ):
             qubit_device_2_wires.reset()
             qubit_device_2_wires.apply(
                 [
                     qml.RZ(0.5, wires=[0]),
-                    qml.QubitStateVector(np.array([0, 1, 0, 0]), wires=[0, 1]),
+                    qml.StatePrep(np.array([0, 1, 0, 0]), wires=[0, 1]),
                 ]
             )
 
@@ -554,7 +554,7 @@ class TestExpval:
 
         qubit_device_1_wire.reset()
         qubit_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
+            [qml.StatePrep(np.array(input), wires=[0])],
             rotations=obs.diagonalizing_gates(),
         )
         res = qubit_device_1_wire.expval(obs)
@@ -594,7 +594,7 @@ class TestVar:
 
         qubit_device_1_wire.reset()
         qubit_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
+            [qml.StatePrep(np.array(input), wires=[0])],
             rotations=obs.diagonalizing_gates(),
         )
         res = qubit_device_1_wire.var(obs)
@@ -759,7 +759,7 @@ class TestLightningGPUIntegration:
 
         @qml.qnode(qubit_device_2_wires)
         def circuit():
-            qml.QubitStateVector(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
+            qml.StatePrep(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             op(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
@@ -799,9 +799,9 @@ class TestLightningGPUIntegration:
             ("BasisState", [0, 0], [1, 1]),
             ("BasisState", [1, 0], [-1, 1]),
             ("BasisState", [0, 1], [1, -1]),
-            ("QubitStateVector", [1, 0, 0, 0], [1, 1]),
-            ("QubitStateVector", [0, 0, 1, 0], [-1, 1]),
-            ("QubitStateVector", [0, 1, 0, 0], [1, -1]),
+            ("StatePrep", [1, 0, 0, 0], [1, 1]),
+            ("StatePrep", [0, 0, 1, 0], [-1, 1]),
+            ("StatePrep", [0, 1, 0, 0], [1, -1]),
         ],
     )
     def test_supported_state_preparation(
@@ -847,11 +847,11 @@ class TestLightningGPUIntegration:
     @pytest.mark.parametrize(
         "name,par,wires,expected_output",
         [
-            ("QubitStateVector", [0, 1], [1], [1, -1]),
-            ("QubitStateVector", [0, 1], [0], [-1, 1]),
-            ("QubitStateVector", [1.0 / np.sqrt(2), 1.0 / np.sqrt(2)], [1], [1, 0]),
-            ("QubitStateVector", [1j / 2.0, np.sqrt(3) / 2.0], [1], [1, -0.5]),
-            ("QubitStateVector", [(2 - 1j) / 3.0, 2j / 3.0], [0], [1 / 9.0, 1]),
+            ("StatePrep", [0, 1], [1], [1, -1]),
+            ("StatePrep", [0, 1], [0], [-1, 1]),
+            ("StatePrep", [1.0 / np.sqrt(2), 1.0 / np.sqrt(2)], [1], [1, 0]),
+            ("StatePrep", [1j / 2.0, np.sqrt(3) / 2.0], [1], [1, -0.5]),
+            ("StatePrep", [(2 - 1j) / 3.0, 2j / 3.0], [0], [1 / 9.0, 1]),
         ],
     )
     def test_state_vector_2_qubit_subset(
@@ -875,7 +875,7 @@ class TestLightningGPUIntegration:
         "name,par,wires,expected_output",
         [
             (
-                "QubitStateVector",
+                "StatePrep",
                 [
                     1j / np.sqrt(10),
                     (1 - 2j) / np.sqrt(10),
@@ -890,32 +890,32 @@ class TestLightningGPUIntegration:
                 [1 / 5.0, 1.0, -4 / 5.0],
             ),
             (
-                "QubitStateVector",
+                "StatePrep",
                 [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)],
                 [0, 2],
                 [0.0, 1.0, 0.0],
             ),
             (
-                "QubitStateVector",
+                "StatePrep",
                 [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)],
                 [0, 1],
                 [0.0, 0.0, 1.0],
             ),
-            ("QubitStateVector", [0, 1, 0, 0, 0, 0, 0, 0], [2, 1, 0], [-1.0, 1.0, 1.0]),
+            ("StatePrep", [0, 1, 0, 0, 0, 0, 0, 0], [2, 1, 0], [-1.0, 1.0, 1.0]),
             (
-                "QubitStateVector",
+                "StatePrep",
                 [0, 1j, 0, 0, 0, 0, 0, 0],
                 [0, 2, 1],
                 [1.0, -1.0, 1.0],
             ),
             (
-                "QubitStateVector",
+                "StatePrep",
                 [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)],
                 [1, 0],
                 [-1.0, 0.0, 1.0],
             ),
             (
-                "QubitStateVector",
+                "StatePrep",
                 [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)],
                 [0, 1],
                 [0.0, -1.0, 1.0],
@@ -1032,7 +1032,7 @@ class TestLightningGPUIntegration:
 
         @qml.qnode(qubit_device_2_wires)
         def circuit():
-            qml.QubitStateVector(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
+            qml.StatePrep(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             op(*par, wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
@@ -1066,7 +1066,7 @@ class TestLightningGPUIntegration:
 
         @qml.qnode(qubit_device_1_wire)
         def circuit():
-            qml.QubitStateVector(np.array(state), wires=[0])
+            qml.StatePrep(np.array(state), wires=[0])
             return qml.expval(obs(wires=[0]))
 
         assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
@@ -1090,7 +1090,7 @@ class TestLightningGPUIntegration:
 
         @qml.qnode(qubit_device_1_wire)
         def circuit():
-            qml.QubitStateVector(np.array(state), wires=[0])
+            qml.StatePrep(np.array(state), wires=[0])
             return qml.expval(obs(*par, wires=[0]))
 
         assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -67,7 +67,7 @@ def one_qubit_block(wires=None):
     qml.PauliX(wires=wires)
 
 
-@pytest.mark.usefixtures("lightning_qubit_dev", "lightning_gpu_qubit_dev")
+@pytest.mark.usefixtures("default_qubit_dev", "lightning_gpu_qubit_dev")
 class TestComparison:
     """A test that compares the output states of ``lightning.gpu`` and ``default.qubit`` for a
     variety of different circuits. This uses ``default.qubit`` as a gold standard to compare
@@ -76,7 +76,7 @@ class TestComparison:
     @pytest.mark.parametrize("basis_state", itertools.product(*[(0, 1)] * 1))
     @pytest.mark.parametrize("wires", [1])
     def test_one_qubit_circuit(
-        self, wires, lightning_qubit_dev, lightning_gpu_qubit_dev, basis_state
+        self, wires, default_qubit_dev, lightning_gpu_qubit_dev, basis_state
     ):
         """Test a single-qubit circuit"""
 
@@ -87,11 +87,11 @@ class TestComparison:
             one_qubit_block(wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
         lightninggpu = qml.QNode(circuit, lightning_gpu_qubit_dev)
 
-        lightning()
-        lightning_state = lightning_qubit_dev.state
+        default()
+        default_state = default_qubit_dev.state
 
         lightninggpu()
 
@@ -100,12 +100,12 @@ class TestComparison:
         )
         lightning_gpu_qubit_dev.syncD2H(lightninggpu_state)  # Copy GPU data to CPU
 
-        assert np.allclose(lightning_state, lightninggpu_state)
+        assert np.allclose(default_state, lightninggpu_state)
 
     @pytest.mark.parametrize("basis_state", itertools.product(*[(0, 1)] * 2))
     @pytest.mark.parametrize("wires", [2])
     def test_two_qubit_circuit(
-        self, wires, lightning_qubit_dev, lightning_gpu_qubit_dev, basis_state
+        self, wires, default_qubit_dev, lightning_gpu_qubit_dev, basis_state
     ):
         """Test a two-qubit circuit"""
 
@@ -126,11 +126,11 @@ class TestComparison:
             qml.CRot(0.2, 0.3, 0.7, wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
         lightninggpu = qml.QNode(circuit, lightning_gpu_qubit_dev)
 
-        lightning()
-        lightning_state = lightning_qubit_dev.state
+        default()
+        default_state = default_qubit_dev.state
 
         lightninggpu()
         lightninggpu_state = np.zeros(2**lightning_gpu_qubit_dev.num_wires).astype(
@@ -138,12 +138,12 @@ class TestComparison:
         )
         lightning_gpu_qubit_dev.syncD2H(lightninggpu_state)  # Copy GPU data to CPU
 
-        assert np.allclose(lightning_state, lightninggpu_state)
+        assert np.allclose(default_state, lightninggpu_state)
 
     @pytest.mark.parametrize("basis_state", itertools.product(*[(0, 1)] * 3))
     @pytest.mark.parametrize("wires", [3])
     def test_three_qubit_circuit(
-        self, wires, lightning_qubit_dev, lightning_gpu_qubit_dev, basis_state
+        self, wires, default_qubit_dev, lightning_gpu_qubit_dev, basis_state
     ):
         """Test a three-qubit circuit"""
 
@@ -172,11 +172,11 @@ class TestComparison:
             qml.Toffoli(wires=[2, 1, 0])
             return qml.expval(qml.PauliZ(0))
 
-        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
         lightninggpu = qml.QNode(circuit, lightning_gpu_qubit_dev)
 
-        lightning()
-        lightning_state = lightning_qubit_dev.state
+        default()
+        default_state = default_qubit_dev.state
 
         lightninggpu()
         lightninggpu_state = np.zeros(2**lightning_gpu_qubit_dev.num_wires).astype(
@@ -184,12 +184,12 @@ class TestComparison:
         )
         lightning_gpu_qubit_dev.syncD2H(lightninggpu_state)  # Copy GPU data to CPU
 
-        assert np.allclose(lightning_state, lightninggpu_state)
+        assert np.allclose(default_state, lightninggpu_state)
 
     @pytest.mark.parametrize("basis_state", itertools.product(*[(0, 1)] * 4))
     @pytest.mark.parametrize("wires", [4])
     def test_four_qubit_circuit(
-        self, wires, lightning_qubit_dev, lightning_gpu_qubit_dev, basis_state
+        self, wires, default_qubit_dev, lightning_gpu_qubit_dev, basis_state
     ):
         """Test a four-qubit circuit"""
 
@@ -223,11 +223,11 @@ class TestComparison:
             qml.Toffoli(wires=[2, 1, 0])
             return qml.expval(qml.PauliZ(0))
 
-        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
         lightninggpu = qml.QNode(circuit, lightning_gpu_qubit_dev)
 
-        lightning()
-        lightning_state = lightning_qubit_dev.state
+        default()
+        default_state = default_qubit_dev.state
 
         lightninggpu()
         lightninggpu_state = np.zeros(2**lightning_gpu_qubit_dev.num_wires).astype(
@@ -235,13 +235,13 @@ class TestComparison:
         )
         lightning_gpu_qubit_dev.syncD2H(lightninggpu_state)  # Copy GPU data to CPU
 
-        assert np.allclose(lightning_state, lightninggpu_state)
+        assert np.allclose(default_state, lightninggpu_state)
 
     @pytest.mark.parametrize("wires", range(1, 17))
-    def test_n_qubit_circuit(self, wires, lightning_qubit_dev, lightning_gpu_qubit_dev):
+    def test_n_qubit_circuit(self, wires, default_qubit_dev, lightning_gpu_qubit_dev):
         """Test an n-qubit circuit"""
 
-        vec = np.array([1] * (2**wires)) / np.sqrt(2**wires)
+        vec = np.array([1 + 0.0j] * (2**wires)) / np.sqrt(2**wires)
         shape = qml.StronglyEntanglingLayers.shape(2, wires)
         w = np.random.uniform(high=2 * np.pi, size=shape)
 
@@ -252,11 +252,11 @@ class TestComparison:
             qml.StronglyEntanglingLayers(w, wires=range(wires))
             return qml.expval(qml.PauliZ(0))
 
-        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
         lightninggpu = qml.QNode(circuit, lightning_gpu_qubit_dev)
 
-        lightning()
-        lightning_state = lightning_qubit_dev.state
+        default()
+        default_state = default_qubit_dev.state
 
         lightninggpu()
         lightninggpu_state = np.zeros(2**lightning_gpu_qubit_dev.num_wires).astype(
@@ -264,4 +264,4 @@ class TestComparison:
         )
         lightning_gpu_qubit_dev.syncD2H(lightninggpu_state)  # Copy GPU data to CPU
 
-        assert np.allclose(lightning_state, lightninggpu_state)
+        assert np.allclose(default_state, lightninggpu_state)

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -248,7 +248,7 @@ class TestComparison:
         def circuit():
             """Prepares the equal superposition state and then applies StronglyEntanglingLayers
             and concludes with a simple PauliZ measurement"""
-            qml.QubitStateVector(vec, wires=range(wires))
+            qml.StatePrep(vec, wires=range(wires))
             qml.StronglyEntanglingLayers(w, wires=range(wires))
             return qml.expval(qml.PauliZ(0))
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -96,7 +96,7 @@ def test_gate_unitary_correct(op, op_name):
     """Test if lightning.gpu correctly applies gates by reconstructing the unitary matrix and
     comparing to the expected version"""
 
-    if op_name in ("BasisState", "QubitStateVector"):
+    if op_name in ("BasisState", "StatePrep"):
         pytest.skip("Skipping operation because it is a state preparation")
 
     if op == None:
@@ -131,7 +131,7 @@ def test_inverse_unitary_correct(op, op_name):
     """Test if lightning.gpu correctly applies inverse gates by reconstructing the unitary matrix
     and comparing to the expected version"""
 
-    if op_name in ("BasisState", "QubitStateVector"):
+    if op_name in ("BasisState", "StatePrep"):
         pytest.skip("Skipping operation because it is a state preparation")
     if op == None:
         pytest.skip("Skipping operation.")


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** With the new design for lightning.qubit, until lightning.gpu can be merged into the new structure, we aim to pin to the previous LQ design. This PR pins `lightning.gpu` CI builds to based on the v0.31.0 release tag of `lightning.qubit.

**Description of the Change:** As above.

**Benefits:** Ensures builds work for the next release.

**Possible Drawbacks:**

**Related GitHub Issues:**
