### PR TITLE
feat: Implement dotWithBraReal

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### New features since last release
 
+  * Implement dotWithBraReal.
+  [(#143)] (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/143)
+  This is used to speed up adjoint differentiation.
+
 ### Breaking changes
 
 ### Improvements

--- a/pennylane_lightning_gpu/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_gpu/src/bindings/Bindings.cpp
@@ -533,6 +533,15 @@ void StateVectorCudaManaged_class_bindings(py::module &m) {
             },
             "Calculate the probabilities for given wires. Results returned in "
             "Col-major order.")
+        .def(
+            "dotWithBraReal",
+            [](StateVectorCudaManaged<PrecisionT> &sv,
+               const StateVectorCudaManaged<PrecisionT> &bra) {
+                // Real only
+                return (sv.innerProductWithSV(bra)).x;
+            },
+            "Calculate the dot product of the statevector with another bra "
+            "statevector and take the real value only.")
         .def("GenerateSamples",
              [](StateVectorCudaManaged<PrecisionT> &sv, size_t num_wires,
                 size_t num_shots) {

--- a/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning_gpu/src/simulator/StateVectorCudaManaged.hpp
@@ -1167,6 +1167,24 @@ class StateVectorCudaManaged
         return cusparsehandle_.get();
     }
 
+    /**
+     * @brief Compute an inner product with the specified statevector.
+     *
+     * @param sv2 Statevector
+     *
+     * @return auto Inner product.
+     */
+    auto innerProductWithSV(const StateVectorCudaManaged<Precision> &sv2) {
+        auto device_id = BaseType::getDataBuffer().getDevTag().getDeviceID();
+        auto stream_id = BaseType::getDataBuffer().getDevTag().getStreamID();
+
+        // <sv2|self>
+        auto ip = innerProdC_CUDA(sv2.getData(), BaseType::getData(),
+                                  BaseType::getLength(), device_id, stream_id,
+                                  getCublasCaller());
+        return ip;
+    }
+
   private:
     SharedCusvHandle handle_;
     SharedCublasCaller cublascaller_;

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -420,6 +420,10 @@ class TestAdjointJacobian:
         res_new = run_circuit(new_obs)
         assert np.allclose(res_old, res_new, atol=tol, rtol=0)
 
+    def test_dotWithBraReal(self, dev_gpu):
+        actual = dev_gpu._gpu_state.dotWithBraReal(dev_gpu._gpu_state)
+        assert np.isclose(actual, 1)
+
 
 class TestAdjointJacobianQNode:
     """Test QNode integration with the adjoint_jacobian method"""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

This functionality is needed to compute adjoint Jacobian of several loss functions that can't be expressed as an observable, e.g. L2 loss and KL divergence. The derivative of those loss functions would require doing adjoint Jacobian on a statevector.

But it should also speed up `np.real(np.vdot(bra, ket_temp))`
```python
    if op.num_params != 0:
        dU = qml.operation.operation_derivative(op)
        ket_temp = apply_operation(qml.QubitUnitary(dU, op.wires), ket)

        dM = 2 * np.real(np.vdot(bra, ket_temp))
        grads.append(dM)
```
in https://pennylane.ai/qml/demos/tutorial_adjoint_diff/, so that the dot product happens within GPU without the need to copy to CPU RAM for a NumPy operation.

I optimized this operation because I found it to take a significant time when I did a line profiling on my adjoint differentiation code.

Note: I didn't run `make test` because it needs a `CUQUANTUM_SDK` env var which I don't know what to specify (it's not defined even within the cuQuantum Appliance). But at least the output of the adjoint differentiation is correct when I compared with the standard method.

**Description of the Change:**
This PR implements a dot product of the statevector with another statevector. For the Python binding, I restrict it to real because it seems simpler. Probably should be changed, but I got this error if I returned the whole complex number instead of the real part
```
TypeError: Unregistered type : float2

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "adjoint_stuff/pennylane_adjoint_dedup.py", line 261, in <module>
    gradient = grad_fn(params)
  File "adjoint_stuff/pennylane_adjoint_dedup.py", line 218, in adjoint_kl
    dM = -2 * bra_norm * dev_gpu._gpu_state.dotWithBraReal(dev_bra._gpu_state)
TypeError: Unable to convert function return value to a Python type! The signature was
        (self: pennylane_lightning_gpu.lightning_gpu_qubit_ops.LightningGPU_C64, arg0: pennylane_lightning_gpu.lightning_gpu_
qubit_ops.LightningGPU_C64) -> float2
```

**Benefits:**
Will result in faster adjoint differentiation calculation.
This is the circuit I used to benchmark the L2 loss function adjoint derivative
```python
@qml.qnode(dev, diff_method="finite-diff")
def circuit(params):
    # define your quantum circuit here
    _ = [qml.RX(params[i], wires=i) for i in range(num_wires)]
    _ += [qml.CZ(wires=(i, i + 1)) for i in range(num_wires - 1)]
    _ += [qml.RX(params[i + num_wires], wires=i) for i in range(num_wires)]
    return qml.state()
```
For 22 qubits, it is 16.7x faster. The first and last numbers are for consistency check that the results match.
```
first last -0.00015151694036875393 -0.00020264025022278406
Elapsed apply_operation 4.2274839878082275
first last -0.0001515170088100138 -0.00020264028214586442
Elapsed lightning 0.25325512886047363
```
For 24 qubits, it is ~108x faster
```
first last -5.618167868933744e-05 -3.4206640947492466e-05
Elapsed apply_operation 97.06205105781555
first last -5.61816643352604e-05 -3.420663656064312e-05
Elapsed lightning 0.8937075138092041
```

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A

cc; @hthayko